### PR TITLE
Add codespell config/workflow and make it fix a typo

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within setup.cfg
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/nwb2bids/reformat.py
+++ b/nwb2bids/reformat.py
@@ -208,7 +208,7 @@ def drop_false_keys(list_of_dict):
 
 def write_tsv(list_of_dict, file_path):
     """
-    Write a list of dictionaries to a tsv file using all keys as colums.
+    Write a list of dictionaries to a tsv file using all keys as columns.
 
     Notes
     -----

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,3 +33,10 @@ tests =
 
 [tool:pytest]
 log_cli = true
+
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =


### PR DESCRIPTION
Workflow/config later might be moved when adopting `pyproject.toml` (ref: #3 )