### PR TITLE
Ensure removal of temporary directory created by `BaseConverter._handle_file_mode()`

### DIFF
--- a/src/nwb2bids/_converters/_base_converter.py
+++ b/src/nwb2bids/_converters/_base_converter.py
@@ -1,7 +1,6 @@
 import abc
 import json
 import pathlib
-import shutil
 import tempfile
 import typing
 
@@ -78,12 +77,19 @@ class BaseConverter(pydantic.BaseModel, abc.ABC):
         if file_mode != "auto":
             return file_mode
 
-        try:
-            test_directory = pathlib.Path(tempfile.mkdtemp(prefix="nwb2bids-"))
-            test_file_path = test_directory / "test_file.txt"
+        with tempfile.TemporaryDirectory(prefix="nwb2bids-") as temp_dir_str:
+            temp_dir_path = pathlib.Path(temp_dir_str)
+
+            # Create a test file
+            test_file_path = temp_dir_path / "test_file.txt"
             test_file_path.touch()
-            (test_directory / "test_symlink.txt").symlink_to(target=test_file_path)
-            shutil.rmtree(path=test_directory, ignore_errors=True)
-            return "symlink"
-        except (OSError, PermissionError):  # Windows can sometimes have trouble with symlinks
-            return "copy"
+
+            try:
+                # Create a symlink to the test file
+                (temp_dir_path / "test_symlink.txt").symlink_to(target=test_file_path)
+            except (OSError, PermissionError, NotImplementedError):  # Windows can sometimes have trouble with symlinks
+                # TODO: log a INFO message here when logging is set up
+                return "copy"
+            else:
+                # If symlink creation was successful, return "symlink"
+                return "symlink"


### PR DESCRIPTION
This PR closes #41.

This PR ensure removals of temporary directory created by `BaseConverter._handle_file_mode()`. Incidentally, it also makes the following minor changes.

1. Making `BaseConverter._handle_file_mode()` a static method since the method never needs to access the class or an instance of `BaseConverter`.
2. Adding `NotImplementedError` is as a potential error from `Path.symlink_to` per its [documentation](https://docs.python.org/3.13/library/pathlib.html#pathlib.Path.symlink_to).
