### PR TITLE
Define hatch-managed environment for type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,15 @@ post-install-commands = ["pip install --group coverage"]
 [tool.hatch.envs.dev]
 post-install-commands = ["pip install --group dev"]
 
+[tool.hatch.envs.types]
+post-install-commands = ["pip install --group types"]
+
 [tool.hatch.envs.all]
 post-install-commands = ["pip install --group all"]
+
+[tool.hatch.envs.types.scripts]
+# Define named script for type checking
+check = "mypy --install-types --non-interactive {args:src/nwb2bids tests}"
 
 
 
@@ -81,13 +88,16 @@ Changelog = "https://github.com/con/nwb2bids/blob/master/CHANGELOG.md"
 nwb2bids = "nwb2bids._command_line_interface._main:_nwb2bids_cli"
 
 [dependency-groups]
+type-stubs = ["pandas-stubs"]
 test = ["pytest"]
 coverage = ["pytest-cov"]
-dev = ["ipython", "pandas-stubs", "pre-commit"]
+dev = ["ipython", "pre-commit", {include-group = "type-stubs"}]
+types = ["mypy", {include-group = "type-stubs"}]
 all = [
     {include-group = "test"},
     {include-group = "coverage"},
-    {include-group = "dev"}
+    {include-group = "dev"},
+    {include-group = "types"},
 ]
 
 


### PR DESCRIPTION
This PR define hatch-managed environment for type checking. With the changes in this PR, in an isolated environment,

```shell
hatch run types:check
```
runs mypy on `src/nwb2bids` and `tests`, and 

```shell
hatch run types:check <path>
```
runs mypy on the given path.

Additionally, one can enter the isolated environment with `hatch shell types` for doing other type checking operations.
