### PR TITLE
Enable mypy plugin for Pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,8 @@ extend-exclude = '''
 )/
 '''
 
-
+[tool.mypy]
+plugins = ["pydantic.mypy"]
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
This PR enables mypy plugin for Pydantic. The plugin adds Pydantic-specific features that improves type checking with mypy. For more info, please checkout https://docs.pydantic.dev/latest/integrations/mypy/ 