### PR TITLE
Set the default python version in a Hatch-managed environment to the project's lowest support Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ packages = ["src/nwb2bids"]
 #
 
 [tool.hatch.envs.default]
+python = "3.10"
 pre-install-commands = ["pip install --upgrade pip"]
 
 # Execute `hatch env create test` to create all test environments.


### PR DESCRIPTION
See individual commit message for details.