### PR TITLE
Update logo image source in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/nwb2bids-color.svg" alt="nwb2bids logo" width="200">
+  <img src="https://raw.githubusercontent.com/con/nwb2bids/main/assets/nwb2bids-color.svg" alt="nwb2bids logo" width="200">
   <h1 align="center">nwb2bids</h1>
   <p align="center">
     <a href="https://pypi.org/project/nwb2bids/"><img alt="Supported Python versions" src="https://img.shields.io/pypi/pyversions/nwb2bids.svg"></a>


### PR DESCRIPTION
@asmacdo I had forgotten there is an issue when you include these things in READMEs that only becomes present in remote builds; e.g., PyPI

Seen on https://pypi.org/project/nwb2bids/0.5.0/

The solution as resolved on other projects is to explicitly refer to the raw GitHub content