### PR TITLE
Blacklisted `h5py` version dependency for macOS platform

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
     "pydantic",
     "typing-extensions",  # TODO: remove when dropping support for Python 3.10
     "ruamel.yaml~=0.18.15",  # https://sourceforge.net/p/ruamel-yaml-clib/tickets/47/
-    "h5py!=3.15.0 ; sys_platform == 'darwin'",  # https://github.com/h5py/h5py/issues/2726
+    "h5py!=3.15.0 ; sys_platform == 'darwin'",  # Reinstate when MacOS14 is minimum
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Fixing today's daily failures