### PR TITLE
Always include session entity, even with only one subject

### DIFF
--- a/src/nwb2bids/_converters/_session_converter.py
+++ b/src/nwb2bids/_converters/_session_converter.py
@@ -62,7 +62,10 @@ class SessionConverter(BaseConverter):
             unique_session_id_to_nwbfile_paths[cache_read_nwb(nwbfile_path).session_id].append(nwbfile_path)
 
         session_converters = [
-            cls(session_id=session_id, nwbfile_paths=nwbfile_paths)
+            cls(
+                session_id=session_id or "0",  # always include ses entity, even 1-session subjects
+                nwbfile_paths=nwbfile_paths,
+            )
             for session_id, nwbfile_paths in unique_session_id_to_nwbfile_paths.items()
         ]
         return session_converters

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,26 +157,6 @@ def multiple_events_nwbfile_path(testing_files_directory: pathlib.Path) -> pathl
 
 
 @pytest.fixture(scope="session")
-def nwbfile_path_with_missing_session_id(testing_files_directory: pathlib.Path) -> pathlib.Path:
-    nwbfile = pynwb.testing.mock.file.mock_NWBFile(session_id=None)
-
-    subject = pynwb.file.Subject(
-        subject_id="123",
-        species="Mus musculus",
-        sex="M",
-    )
-    nwbfile.subject = subject
-
-    events_subdirectory = testing_files_directory / "missing_session_id"
-    events_subdirectory.mkdir(exist_ok=True)
-    nwbfile_path = events_subdirectory / "missing_session_id.nwb"
-    with pynwb.NWBHDF5IO(path=nwbfile_path, mode="w") as file_stream:
-        file_stream.write(nwbfile)
-
-    return nwbfile_path
-
-
-@pytest.fixture(scope="session")
 def directory_with_multiple_nwbfiles(testing_files_directory: pathlib.Path) -> pathlib.Path:
     multiple_nwbfiles_subdirectory = testing_files_directory / "multiple_nwbfiles"
     multiple_nwbfiles_subdirectory.mkdir(exist_ok=True)
@@ -260,6 +240,26 @@ def problematic_nwbfile_path_3(testing_files_directory: pathlib.Path) -> pathlib
     problematic_subdirectory = testing_files_directory / "problematic"
     problematic_subdirectory.mkdir(exist_ok=True)
     nwbfile_path = problematic_subdirectory / "problematic3.nwb"
+    with pynwb.NWBHDF5IO(path=nwbfile_path, mode="w") as file_stream:
+        file_stream.write(nwbfile)
+
+    return nwbfile_path
+
+
+@pytest.fixture(scope="session")
+def problematic_nwbfile_path_missing_session_id(testing_files_directory: pathlib.Path) -> pathlib.Path:
+    nwbfile = pynwb.testing.mock.file.mock_NWBFile(session_id=None)
+
+    subject = pynwb.file.Subject(
+        subject_id="123",
+        species="Mus musculus",
+        sex="M",
+    )
+    nwbfile.subject = subject
+
+    events_subdirectory = testing_files_directory / "missing_session_id"
+    events_subdirectory.mkdir(exist_ok=True)
+    nwbfile_path = events_subdirectory / "missing_session_id.nwb"
     with pynwb.NWBHDF5IO(path=nwbfile_path, mode="w") as file_stream:
         file_stream.write(nwbfile)
 

--- a/tests/unit/test_session_converter.py
+++ b/tests/unit/test_session_converter.py
@@ -41,6 +41,19 @@ def test_session_converter_both_file_and_directory_initialization(
     assert all(isinstance(converter, nwb2bids.SessionConverter) for converter in session_converters)
 
 
+def test_session_converter_defaults_missing_session_id(
+    problematic_nwbfile_path_missing_session_id: pathlib.Path, temporary_bids_directory: pathlib.Path
+):
+    session_converters = nwb2bids.SessionConverter.from_nwb_paths(
+        nwb_paths=[problematic_nwbfile_path_missing_session_id]
+    )
+
+    assert isinstance(session_converters, list)
+    assert len(session_converters) == 1
+    assert isinstance(session_converters[0], nwb2bids.SessionConverter)
+    assert session_converters[0].session_id == "0"
+
+
 def test_session_converter_metadata_extraction(
     minimal_nwbfile_path: pathlib.Path, temporary_bids_directory: pathlib.Path
 ):


### PR DESCRIPTION
If a subject has only one session but `session_id` is not provided, this will be assigned `ses-0`.

Previously this would fail validation: `session_id` is expected to be a `str`. Elsewhere, there are assumptions that a session entity exists, so we should always use it.