### PR TITLE
Use two GitHub tokens in Release with Auto workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Create Release
         run: ~/auto shipit -vv
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          PROTECTED_BRANCH_REVIEWER_TOKEN: ${{ secrets._GITHUB_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets._GITHUB_API_KEY }}
+          PROTECTED_BRANCH_REVIEWER_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
This PR addresses the point of failure pointed out by @CodyCBakerPhD at https://github.com/con/nwb2bids/pull/151#discussion_r2456278018.

However, this still may not solve the auto release problem completely because of the following issues.

- If AUTO uses `secrets.GITHUB_TOKEN` to generate the release event, then the `Upload Package to PyPI` workflow will not be triggered per https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow. (This is most likely the case, but we can still try this solution.) If this solution fails, we will need to create a bot and use its its PAT as instructed in https://github.com/intuit/auto/tree/main/plugins/protected-branch#configuration.
- We may need to populate the `requiredStatusChecks` field in the config of the protected-branch AUTO plugin. @CodyCBakerPhD You may want to help me fulfill this one since I don't have access of the protected branch settings. I think what is needed is the exact names of the required status checks.