### PR TITLE
Restrict sphinx version to below 9.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ coverage = ["pytest-cov"]
 dev = ["ipython", "pre-commit", {include-group = "type-stubs"}]
 types = ["mypy", {include-group = "type-stubs"}]
 docs = [
-    "sphinx",
+    "sphinx<9.0.0",
     "sphinx-tabs",
     "pydata-sphinx-theme",
 ]


### PR DESCRIPTION
I'll leave an issue to recheck if this pin can be relaxed in a few months

The latest release of [Sphinx](https://pypi.org/project/Sphinx/#history) broke our docs because of a chain of relaxed secondary dependencies

Specifically, the latest Sphinx relaxed `docutils<0.22` to `docutils<0.23` and `docutils==0.22` causes a known problem with `sphinx-tabs` (even has an unmerged fix): https://github.com/executablebooks/sphinx-tabs/issues/206

Will ping them upstream but for now just need to get docs runs on all PRs passing