### PR TITLE
Config mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,9 @@ plugins = ["pydantic.mypy"]
 [[tool.mypy.overrides]]
 module = [
   "dandi.*",
+  "datalad.*",
   "h5py",
+  "py.*",
   "pynwb.*",
   "remfile",
 ]


### PR DESCRIPTION
This PR tunes the settings for mypy execution in `pyproject.toml`.

Particularly,
1. It disables mypy errors regarding modules that don't come with type info using the `ignore_missing_imports` setting.
2. It includes dependencies in test in the type checking environment so that type checking can be done on tests with type info of the dependencies, such as pytest.

Incidentally, this PR also add a convenient script to the `types` Hatch environment for running mypy without any cached type information of modules.