### PR TITLE
Disable mypy error code prop-decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ extend-exclude = '''
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]
+disable_error_code = ["prop-decorator"]
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
Decorators on top of `@property` are not yet supported by mypy. However, [`pydantic.computed_field`](https://docs.pydantic.dev/latest/concepts/fields/#the-computed_field-decorator) should be applied on top of `@property`. This PR disables the `prop-decorator` mypy error, which appears whenever a decorator is applied on top of `@property`, as suggested by https://github.com/python/mypy/issues/14461.