### PR TITLE
Eliminate mypy errors in `src/nwb2bids/bids_models/_probes.py`

### DIFF
--- a/src/nwb2bids/bids_models/_probes.py
+++ b/src/nwb2bids/bids_models/_probes.py
@@ -111,8 +111,7 @@ class ProbeTable(BaseMetadataContainerModel):
         file_path : path
             The path to the output JSON file.
         """
-        if isinstance(file_path, str):
-            file_path = pathlib.Path(file_path)
+        file_path = pathlib.Path(file_path)
 
         with file_path.open(mode="w") as file_stream:
             json.dump(obj=dict(), fp=file_stream, indent=4)


### PR DESCRIPTION
Incidentally, this change also corrects the handling of the arguments to `ProbeTable.to_json`.