### PR TITLE
bump codecov-action

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload full coverage to Codecov
         if: ${{ matrix.python == '3.13' && matrix.os == 'ubuntu-latest' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./codecov.xml


### PR DESCRIPTION
90 days after a PR (is opened, merged, or branch is deleted, not sure which) codecov gets triggered again. 

https://github.com/codecov/feedback/issues/665

There were a few complaints about this but most seem to be from 2024. I didnt see anything in the changelog or a PR that claims to fix, but the original bug report was closed https://github.com/codecov/codecov-action/issues/1599. 

I guess lets just bump and hope it stops in 90 days lol