### PR TITLE
Provide a more precise solution to temporarily ignore selected mypy errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,15 +33,6 @@ repos:
     rev: v1.19.1
     hooks:
     -   id: mypy
-        args:
-         - "--disable-error-code=union-attr"
-         - "--disable-error-code=arg-type"
-         - "--disable-error-code=call-arg"
-         - "--disable-error-code=assignment"
-         - "--disable-error-code=attr-defined"
-         - "--disable-error-code=import-not-found"
-         - "--disable-error-code=func-returns-value"
-         - "--disable-error-code=override"
 
         files: ^(src/|tests/)
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,8 +34,6 @@ repos:
     hooks:
     -   id: mypy
         args:
-         - "--install-types"
-         - "--non-interactive"
          - "--disable-error-code=union-attr"
          - "--disable-error-code=arg-type"
          - "--disable-error-code=call-arg"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
          - "--disable-error-code=func-returns-value"
          - "--disable-error-code=override"
 
-        files: src  # TODO: expand to ^(src/|tests/)
+        files: ^(src/|tests/)
         additional_dependencies:
          - "types-PyYAML"
          - "pandas-stubs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,105 @@ module = [
 ]
 ignore_missing_imports = true
 
+# === Temporary mypy ignores for selected files ===
+[[tool.mypy.overrides]]
+module = ["*._probes"]
+disable_error_code = ["attr-defined"]
+
+[[tool.mypy.overrides]]
+module = ["*._electrodes"]
+disable_error_code = ["override", "union-attr"]
+
+[[tool.mypy.overrides]]
+module = ["nwb2bids.bids_models._channels"]
+disable_error_code = ["union-attr"]
+
+[[tool.mypy.overrides]]
+module = ["nwb2bids.bids_models._bids_session_metadata"]
+disable_error_code = ["arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["nwb2bids._converters._session_converter"]
+disable_error_code = ["call-arg", "union-attr"]
+
+[[tool.mypy.overrides]]
+module = ["nwb2bids._converters._dataset_converter"]
+disable_error_code = ["call-arg", "union-attr", "func-returns-value"]
+
+[[tool.mypy.overrides]]
+module = ["nwb2bids._core._convert_nwb_dataset"]
+disable_error_code = ["call-arg"]
+
+[[tool.mypy.overrides]]
+module = ["nwb2bids._command_line_interface._main"]
+disable_error_code = ["assignment", "arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["conftest"]
+disable_error_code = ["arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["test_utils"]
+disable_error_code = ["arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["test_session_converter"]
+disable_error_code = ["call-arg", "arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["test_run_config"]
+disable_error_code = ["call-arg", "misc"]
+
+[[tool.mypy.overrides]]
+module = ["test_remote_dataset_converter"]
+disable_error_code = ["call-arg", "union-attr"]
+
+[[tool.mypy.overrides]]
+module = ["test_directory_conditions"]
+disable_error_code = ["arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["test_dataset_converter"]
+disable_error_code = ["call-arg", "arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["test_remote_convert_nwb_dataset"]
+disable_error_code = ["call-arg", "union-attr", "arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["test_notifications"]
+disable_error_code = ["call-arg"]
+
+[[tool.mypy.overrides]]
+module = ["test_icephys_tutorial"]
+disable_error_code = ["call-arg", "arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["test_events"]
+disable_error_code = ["call-arg", "arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["test_edge_cases"]
+disable_error_code = ["call-arg", "arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["test_convert_nwb_dataset"]
+disable_error_code = ["call-arg", "arg-type", "var-annotated"]
+
+[[tool.mypy.overrides]]
+module = ["test_conversion_with_sanitization"]
+disable_error_code = ["call-arg", "arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["test_sanitization_cli"]
+disable_error_code = ["str-bytes-safe", "arg-type"]
+
+[[tool.mypy.overrides]]
+module = ["test_cli"]
+disable_error_code = ["str-bytes-safe", "arg-type"]
+
+# === Temporary mypy ignores for selected files section ends ===
+
 [tool.ruff]
 exclude = [
   "*/__init__.py"


### PR DESCRIPTION
This PR adjusted the `mypy` configuration proposed by #272 to temporarily ignore selected mypy errors more precisely. Additionally, it also adjusted the mypy pre-commit repo to run mypy on the `tests/` as well.