### PR TITLE
Expanded data standards documentation section

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,15 +97,77 @@ We are happy to help and appreciate your feedback.
 
 
 
-Related links
--------------
+Data Standards and Related Resources
+------------------------------------
 
-- `NWB Overview <https://nwb-overview.readthedocs.io/en/latest/>`_: An overview of the NWB standard and ecosystem.
+Understanding the Standardization Landscape
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- `NWB Guide <https://nwb-guide.readthedocs.io/en/latest/>`_: A no-code solution to conversion to NWB format.
+**nwb2bids** operates at the intersection of multiple neuroscience data standards.
+This section clarifies which standards are currently supported, which are planned for future implementation, and how they relate to the broader standardization ecosystem.
 
-- `NeuroConv <https://neuroconv.readthedocs.io/en/latest/>`_: A low-code Python library for conversion to NWB format.
+For a comprehensive overview of neuroscience data standards and their relationships, see the `SfN 2025: "The Ecosystem of Standards in Neuroscience: Which Ones Are For You?" Poster <https://doi.org/10.5281/zenodo.18333007>`_ by Oliver Contier et al.
 
-- `NWB Format Specification <https://nwb-schema.readthedocs.io/en/latest/>`_: More information regarding the core NWB format.
+Currently Supported Standards
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- `BIDS Specification <https://bids.neuroimaging.io/>`_: More information regarding the core BIDS standard.
+**nwb2bids** currently provides full support for:
+
+* **NWB (Neurodata Without Borders)**: A data standard for neurophysiology that provides a common format for cellular-based neurophysiology data, along with trial structure, metadata, and behavioral data.
+  **nwb2bids** reads and processes NWB files as input.
+
+  - `NWB Format Specification <https://nwb-schema.readthedocs.io/en/latest/>`_: Technical specification of the NWB format
+  - `NWB Overview <https://nwb-overview.readthedocs.io/en/latest/>`_: High-level overview of NWB and its ecosystem
+  - `NWB Extensions <https://nwb-extensions.github.io/>`_: Catalog of community-developed extensions (NDX) that extend NWB for specific data types and use cases
+
+* **BIDS (Brain Imaging Data Structure)**: A specification for organizing neuroscience data in a standardized directory structure with accompanying metadata.
+  **nwb2bids** outputs data organized according to BIDS conventions.
+
+  - `BIDS Specification <https://bids.neuroimaging.io/>`_: Official BIDS specification
+  - `BIDS Extension Proposals (BEPs) <https://bids.neuroimaging.io/extensions/beps.html>`_: Overview of ongoing extensions to BIDS for additional modalities (eye tracking, microscopy, etc.).
+    Note that this page evolves as new extensions are proposed and adopted.
+  - **BEP32 (BIDS Extension Proposal 32)**: Currently supported for micro-electrode electrophysiology, including extracellular (``ecephys``) and intracellular (``icephys``) electrophysiology, as well as associated behavioral events.
+    See the `BEP32 pull request <https://github.com/bids-standard/bids-specification/pull/1705>`_ for specification details.
+
+* **HED (Hierarchical Event Descriptors)**: Basic support for annotating events and experimental structure with standardized vocabularies.
+  **nwb2bids** currently includes HED version specification (v8.3.0) in dataset metadata and automatically assigns basic HED tags to event tables (e.g., "Experimental-trial" for trials, "Time-block" for epochs).
+  Future work will extend HED annotation capabilities.
+
+Planned Future Support
+~~~~~~~~~~~~~~~~~~~~~~
+
+We are actively planning to extend **nwb2bids** support to include:
+
+* **ndx-events**: NWB extension for representing event data
+* **ndx-pose + BIDS motion**: For pose estimation and motion capture data
+* Additional data modalities: stimuli, videos, microscopy, and eye tracking
+* Extended HED annotation capabilities beyond basic tagging
+
+These extensions will require integration with their respective standards and may depend on external tooling or additional NWB extensions.
+
+Related Standardization Efforts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**nwb2bids** operates in the broader context of neuroscience data standardization initiatives:
+
+* `DICOM WG-32: Neurophysiology Data <https://www.dicomstandard.org/activity/wgs/wg-32>`_: The Digital Imaging and Communications in Medicine (DICOM) working group focused on standardizing neurophysiology data, including EEG, EMG, evoked potentials, and other clinical neurophysiology signals.
+  While DICOM and NWB/BIDS serve different use cases and communities, awareness of parallel standardization efforts helps users understand the broader landscape of neurophysiology data standards.
+
+Related Tools and Converters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**nwb2bids** is part of a broader ecosystem of tools for working with NWB and BIDS data:
+
+**NWB Converters:**
+
+- `NWB Guide <https://nwb-guide.readthedocs.io/en/latest/>`_: A no-code graphical interface for converting data to NWB format
+
+- `NeuroConv <https://neuroconv.readthedocs.io/en/latest/>`_: A Python library providing low-code conversion pipelines to NWB format from various proprietary and open formats
+
+**BIDS Converters for Other Modalities:**
+
+- `BIDS Converters <https://bids.neuroimaging.io/tools/converters.html>`_: Collection of converters for different neuroimaging and neuroscience data modalities (MRI, EEG, MEG, iEEG, PET, and more)
+
+**AI Assistants for Standards:**
+
+- `qp - AI Assistants Collection <https://github.com/magland/qp>`_: A curated collection of AI assistants for various neuroscience projects and data standards, providing interactive help with BIDS, NWB, and related tools

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -129,7 +129,7 @@ Currently Supported Standards
   - **BEP32 (BIDS Extension Proposal 32)**: Currently supported for micro-electrode electrophysiology, including extracellular (``ecephys``) and intracellular (``icephys``) electrophysiology, as well as associated behavioral events.
     See the `BEP32 pull request <https://github.com/bids-standard/bids-specification/pull/1705>`_ for specification details.
 
-* **HED (Hierarchical Event Descriptors)**: Basic support for annotating events and experimental structure with standardized vocabularies.
+* **HED (Hierarchical Event Descriptors)** (`hedtags.org <https://www.hedtags.org/>`_): Basic support for annotating events and experimental structure with standardized vocabularies.
   **nwb2bids** currently includes HED version specification (v8.3.0) in dataset metadata and automatically assigns basic HED tags to event tables (e.g., "Experimental-trial" for trials, "Time-block" for epochs).
   Future work will extend HED annotation capabilities.
 
@@ -138,9 +138,9 @@ Planned Future Support
 
 We are actively planning to extend **nwb2bids** support to include:
 
-* **ndx-events**: NWB extension for representing event data
-* **ndx-pose + BIDS motion**: For pose estimation and motion capture data
-* Additional data modalities: stimuli, videos, microscopy, and eye tracking
+* `ndx-events <https://github.com/rly/ndx-events>`_: NWB extension for representing timestamped event and TTL pulse data
+* `ndx-pose <https://github.com/rly/ndx-pose>`_ + `BIDS motion <https://bids-specification.readthedocs.io/en/stable/modality-specific-files/motion.html>`_: For pose estimation and motion capture data
+* Additional data modalities: stimuli, videos, `microscopy (BEP031) <https://www.frontiersin.org/journals/neuroscience/articles/10.3389/fnins.2022.871228/full>`_, and `eye tracking (BEP020) <https://bids.neuroimaging.io/extensions/beps/bep_020.html>`_
 * Extended HED annotation capabilities beyond basic tagging
 
 These extensions will require integration with their respective standards and may depend on external tooling or additional NWB extensions.
@@ -150,7 +150,7 @@ Related Standardization Efforts
 
 **nwb2bids** operates in the broader context of neuroscience data standardization initiatives:
 
-* `DICOM WG-32: Neurophysiology Data <https://www.dicomstandard.org/activity/wgs/wg-32>`_: The Digital Imaging and Communications in Medicine (DICOM) working group focused on standardizing neurophysiology data, including EEG, EMG, evoked potentials, and other clinical neurophysiology signals.
+* `DICOM <https://www.dicomstandard.org/>`_ `WG-32: Neurophysiology Data <https://www.dicomstandard.org/activity/wgs/wg-32>`_: The Digital Imaging and Communications in Medicine (DICOM) working group focused on standardizing neurophysiology data, including EEG, EMG, evoked potentials, and other clinical neurophysiology signals.
   While DICOM and NWB/BIDS serve different use cases and communities, awareness of parallel standardization efforts helps users understand the broader landscape of neurophysiology data standards.
 
 Related Tools and Converters

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,7 +106,7 @@ Understanding the Standardization Landscape
 **nwb2bids** operates at the intersection of multiple neuroscience data standards.
 This section clarifies which standards are currently supported, which are planned for future implementation, and how they relate to the broader standardization ecosystem.
 
-For a comprehensive overview of neuroscience data standards and their relationships, see the `SfN 2025: "The Ecosystem of Standards in Neuroscience: Which Ones Are For You?" Poster <https://doi.org/10.5281/zenodo.18333007>`_ by Oliver Contier et al.
+For a comprehensive overview of neuroscience data standards and their relationships, see the `SfN 2025: "The Ecosystem of Standards in Neuroscience: Which Ones Are For You?" Poster <https://doi.org/10.5281/zenodo.18333007>`_ by Oliver Rübel *et al*.
 
 Currently Supported Standards
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -116,14 +116,14 @@ Currently Supported Standards
 * **NWB (Neurodata Without Borders)**: A data standard for neurophysiology that provides a common format for cellular-based neurophysiology data, along with trial structure, metadata, and behavioral data.
   **nwb2bids** reads and processes NWB files as input.
 
-  - `NWB Format Specification <https://nwb-schema.readthedocs.io/en/latest/>`_: Technical specification of the NWB format
-  - `NWB Overview <https://nwb-overview.readthedocs.io/en/latest/>`_: High-level overview of NWB and its ecosystem
-  - `NWB Extensions <https://nwb-extensions.github.io/>`_: Catalog of community-developed extensions (NDX) that extend NWB for specific data types and use cases
+  - `NWB Format Specification <https://nwb-schema.readthedocs.io/en/latest/>`_: Technical specification of the NWB format.
+  - `NWB Overview <https://nwb-overview.readthedocs.io/en/latest/>`_: High-level overview of NWB and its ecosystem.
+  - `NWB Extensions <https://nwb-extensions.github.io/>`_: Catalog of community-developed extensions (NDX) that extend NWB for specific data types and use cases.
 
 * **BIDS (Brain Imaging Data Structure)**: A specification for organizing neuroscience data in a standardized directory structure with accompanying metadata.
   **nwb2bids** outputs data organized according to BIDS conventions.
 
-  - `BIDS Specification <https://bids.neuroimaging.io/>`_: Official BIDS specification
+  - `BIDS Specification <https://bids.neuroimaging.io/>`_: Official BIDS specification.
   - `BIDS Extension Proposals (BEPs) <https://bids.neuroimaging.io/extensions/beps.html>`_: Overview of ongoing extensions to BIDS for additional modalities (eye tracking, microscopy, etc.).
     Note that this page evolves as new extensions are proposed and adopted.
   - **BEP32 (BIDS Extension Proposal 32)**: Currently supported for micro-electrode electrophysiology, including extracellular (``ecephys``) and intracellular (``icephys``) electrophysiology, as well as associated behavioral events.
@@ -138,10 +138,10 @@ Planned Future Support
 
 We are actively planning to extend **nwb2bids** support to include:
 
-* `ndx-events <https://github.com/rly/ndx-events>`_: NWB extension for representing timestamped event and TTL pulse data
-* `ndx-pose <https://github.com/rly/ndx-pose>`_ + `BIDS motion <https://bids-specification.readthedocs.io/en/stable/modality-specific-files/motion.html>`_: For pose estimation and motion capture data
+* `ndx-events <https://github.com/rly/ndx-events>`_: NWB extension for representing timestamped event and TTL pulse data.
+* `ndx-pose <https://github.com/rly/ndx-pose>`_ + `BIDS motion <https://bids-specification.readthedocs.io/en/stable/modality-specific-files/motion.html>`_: For pose estimation and motion capture data.
 * Additional data modalities: stimuli, videos, `microscopy (BEP031) <https://www.frontiersin.org/journals/neuroscience/articles/10.3389/fnins.2022.871228/full>`_, and `eye tracking (BEP020) <https://bids.neuroimaging.io/extensions/beps/bep_020.html>`_
-* Extended HED annotation capabilities beyond basic tagging
+* Extended HED annotation capabilities beyond basic tagging.
 
 These extensions will require integration with their respective standards and may depend on external tooling or additional NWB extensions.
 
@@ -160,13 +160,13 @@ Related Tools and Converters
 
 **NWB Converters:**
 
-- `NWB Guide <https://nwb-guide.readthedocs.io/en/latest/>`_: A no-code graphical interface for converting data to NWB format
+- `NWB Guide <https://nwb-guide.readthedocs.io/en/latest/>`_: A no-code graphical interface for converting data to NWB format.
 
-- `NeuroConv <https://neuroconv.readthedocs.io/en/latest/>`_: A Python library providing low-code conversion pipelines to NWB format from various proprietary and open formats
+- `NeuroConv <https://neuroconv.readthedocs.io/en/latest/>`_: A Python library providing low-code conversion pipelines to NWB format from various proprietary and open formats.
 
 **BIDS Converters for Other Modalities:**
 
-- `BIDS Converters <https://bids.neuroimaging.io/tools/converters.html>`_: Collection of converters for different neuroimaging and neuroscience data modalities (MRI, EEG, MEG, iEEG, PET, and more)
+- `BIDS Converters <https://bids.neuroimaging.io/tools/converters.html>`_: Collection of converters for different neuroimaging and neuroscience data modalities (MRI, EEG, MEG, iEEG, PET, and more).
 
 **AI Assistants for Standards:**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -170,4 +170,4 @@ Related Tools and Converters
 
 **AI Assistants for Standards:**
 
-- `qp - AI Assistants Collection <https://github.com/magland/qp>`_: A curated collection of AI assistants for various neuroscience projects and data standards, providing interactive help with BIDS, NWB, and related tools
+- `qp - AI Assistants Collection <https://github.com/magland/qp>`_: A curated collection of AI assistants for various neuroscience projects and data standards, providing interactive help with BIDS, NWB, and related tools.


### PR DESCRIPTION
- Fixes #222 

by transforming the "Related links" section into a comprehensive "Data Standards and Related Resources" guide that clarifies the standardization landscape. Organizes standards into currently supported (NWB, BIDS/BEP32, HED with basic support) vs. planned future support. Adds references to NWB Extensions, BIDS BEPs, DICOM WG-32, BIDS converters, and qp AI assistants. Includes placeholder for Standards Poster (Zenodo DOI pending). Formatted with one sentence per line.

TODO
- [x] finish up zenodo record for Standards poster and post here