### PR TITLE
Use GitHub App token for auto-release check runs

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -31,8 +31,14 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AUTO_APP_ID }}
+          private-key: ${{ secrets.AUTO_APP_PRIVATE_KEY }}
       - name: Create Release
         run: ~/auto shipit -vv
         env:
-          GITHUB_TOKEN: ${{ secrets._GITHUB_API_KEY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PROTECTED_BRANCH_REVIEWER_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
The Checks API requires authentication via a GitHub App. This generates an app token to allow Auto to create check runs when merging release PRs.