### PR TITLE
Eliminate static typing errors in `_probes.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,10 +177,6 @@ ignore_missing_imports = true
 
 # === Temporary mypy ignores for selected files ===
 [[tool.mypy.overrides]]
-module = ["*._probes"]
-disable_error_code = ["attr-defined"]
-
-[[tool.mypy.overrides]]
 module = ["nwb2bids.bids_models._bids_session_metadata"]
 disable_error_code = ["arg-type"]
 

--- a/src/nwb2bids/bids_models/_probes.py
+++ b/src/nwb2bids/bids_models/_probes.py
@@ -169,7 +169,7 @@ class ProbeTable(BaseMetadataContainerModel):
     def _check_fields(self) -> None:
         self._internal_notifications = []
 
-        probes_missing_description = [probe for probe in self.probes if probe.description is None]
+        probes_missing_description = [probe for probe in self.probes if getattr(probe, "description", None) is None]
         for _ in probes_missing_description:
             notification = Notification.from_definition(
                 identifier="MissingDescription",


### PR DESCRIPTION
`description` is not declared field in the model but added as an extra field. This change avoids accessing the attribute using
the attribute syntax.

This PR closes #304.