### PR TITLE
Added general metadata support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 default_install_hook_types:
   - pre-commit
-  - commit-msg
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,9 @@ python_maximum_signature_line_length = 88
 
 # Link checker
 linkcheck_anchors = False
-linkcheck_ignore = []
+linkcheck_ignore = [
+    "https://zenodo.org/*",  # Getting 403 even though link is fine as of 03/2026
+]
 
 # Disable left (Section Navigation) sidebars for specific sections
 html_sidebars = {

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -10,7 +10,6 @@ import dateutil
 import pandas
 import pynwb
 import pynwb.testing.mock.file
-import sybil
 import sybil.parsers.rest
 
 import nwb2bids

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -2,8 +2,8 @@
 import datetime
 import json
 import pathlib
-import shutil
 import subprocess
+import typing
 import uuid
 
 import dateutil
@@ -28,16 +28,17 @@ def bash_evaluator(example):
         return f"Command failed (exit {result.returncode}):\n{result.stderr}"
 
 
-def sybil_setup(namespace):
-    """Clean and regenerate tutorial data before tests.
+def sybil_setup(namespace: dict[str, typing.Any]):
+    """
+    Clean and regenerate tutorial data before tests.
 
     NOTE: This runs once per document, not per code block. If multiple examples
     in the same document write to the same output directory, they will conflict.
     Use distinct output directories (e.g., bids_dataset_cli_1, bids_dataset_py_1).
     """
     tutorial_base = nwb2bids.testing.get_tutorial_directory()
-    if tutorial_base.exists():
-        shutil.rmtree(tutorial_base)
+    # if tutorial_base.exists():
+    #     shutil.rmtree(tutorial_base)
 
     nwb2bids.testing.generate_ephys_tutorial(mode="file")
     nwb2bids.testing.generate_ephys_tutorial(mode="dataset")
@@ -85,6 +86,7 @@ def sybil_setup(namespace):
     namespace["tutorial_nwbfile"] = tutorial_nwbfile
 
     namespace["expected_files"] = expected_files
+
 
 
 pytest_collect_file = Sybil(

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -10,9 +10,10 @@ import dateutil
 import pandas
 import pynwb
 import pynwb.testing.mock.file
-from sybil import Sybil
-from sybil.parsers.rest import CodeBlockParser, PythonCodeBlockParser, SkipParser
+import sybil
 
+# from sybil import Sybil
+# from sybil.parsers.rest import CodeBlockParser, PythonCodeBlockParser, SkipParser
 import nwb2bids
 
 
@@ -89,11 +90,11 @@ def sybil_setup(namespace: dict[str, typing.Any]):
 
 
 
-pytest_collect_file = Sybil(
+pytest_collect_file = sybil.Sybil(
     parsers=[
-        SkipParser(),
-        CodeBlockParser(language="bash", evaluator=bash_evaluator),
-        PythonCodeBlockParser(),
+        sybil.parsers.rest.SkipParser(),
+        sybil.parsers.rest.CodeBlockParser(language="bash", evaluator=bash_evaluator),
+        sybil.parsers.rest.PythonCodeBlockParser(),
     ],
     patterns=["tutorials.rst", "conversion_gallery.rst"],
     setup=sybil_setup,

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -11,9 +11,8 @@ import pandas
 import pynwb
 import pynwb.testing.mock.file
 import sybil
+import sybil.parsers.rest
 
-# from sybil import Sybil
-# from sybil.parsers.rest import CodeBlockParser, PythonCodeBlockParser, SkipParser
 import nwb2bids
 
 

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -2,6 +2,7 @@
 import datetime
 import json
 import pathlib
+import shutil
 import subprocess
 import typing
 import uuid
@@ -36,8 +37,8 @@ def sybil_setup(namespace: dict[str, typing.Any]):
     Use distinct output directories (e.g., bids_dataset_cli_1, bids_dataset_py_1).
     """
     tutorial_base = nwb2bids.testing.get_tutorial_directory()
-    # if tutorial_base.exists():
-    #     shutil.rmtree(tutorial_base)
+    if tutorial_base.exists():
+        shutil.rmtree(tutorial_base)  # May cause issues on Windows, but does not show up in CI
 
     nwb2bids.testing.generate_ephys_tutorial(mode="file")
     nwb2bids.testing.generate_ephys_tutorial(mode="dataset")

--- a/docs/conversion_gallery.rst
+++ b/docs/conversion_gallery.rst
@@ -146,6 +146,38 @@ And the corresponding ``participants.json`` file provides detailed descriptions 
 
 
 
+General Metadata
+----------------
+
+NWB files can contain a number of high-level metadata fields that describe the overall experiment, acquisition parameters, and other details that don't neatly belong to specific neurodata types.
+These fields are typically set on the top-level ``pynwb.NWBFile`` object.
+
+**NWB file metadata:**
+
+.. code-block:: python
+
+   nwbfile = pynwb.NWBFile(
+      # TODO
+   )
+
+.. invisible-code-block: python
+
+   tutorial_probe = tutorial_nwbfile.devices["ExampleProbe"]
+
+   assert probe.name == tutorial_probe.name
+   assert probe.manufacturer == tutorial_probe.manufacturer
+   assert probe.description == tutorial_probe.description
+
+**BIDS general metadata:**
+
+Depending on the modality, ``ecephys.json`` or ``icephys.json`` file contains metadata such as:
+
+.. code-block:: json
+
+   {}
+
+
+
 Ecephys Probes
 --------------
 

--- a/docs/conversion_gallery.rst
+++ b/docs/conversion_gallery.rst
@@ -108,8 +108,8 @@ The ``participants.tsv`` file contains a row for each subject:
 
 .. note::
 
-	The column order in all TSV files is strictly enforced by BIDS validation, and **nwb2bids** will make every
-	effort to produce valid files based on input data.
+   The column order in all TSV files is strictly enforced by BIDS validation, and **nwb2bids** will make every
+   effort to produce valid files based on input data.
 
 .. invisible-code-block: python
 
@@ -150,31 +150,54 @@ General Metadata
 ----------------
 
 NWB files can contain a number of high-level metadata fields that describe the overall experiment, acquisition parameters, and other details that don't neatly belong to specific neurodata types.
-These fields are typically set on the top-level ``pynwb.NWBFile`` object.
+These fields are typically set on the top-level ``pynwb.NWBFile`` object, though there are a few that belong to
+particular subfields such as ``pynwb.DeviceModel``.
 
 **NWB file metadata:**
 
 .. code-block:: python
 
-   nwbfile = pynwb.NWBFile(
-      # TODO
+   general_metadata_nwbfile = pynwb.NWBFile(
+       session_id="B",
+       session_start_time=datetime.datetime(1970, 1, 2, tzinfo=dateutil.tz.tzutc()),
+       session_description="An example NWB file used for demonstration of general metadata mapping.",
+       identifier=uuid.uuid4().hex,
+
    )
-
-.. invisible-code-block: python
-
-   tutorial_probe = tutorial_nwbfile.devices["ExampleProbe"]
-
-   assert probe.name == tutorial_probe.name
-   assert probe.manufacturer == tutorial_probe.manufacturer
-   assert probe.description == tutorial_probe.description
+   general_metadata_device = pynwb.file.DeviceModel(
+       name="ExampleDevice",
+       description="This is an example device used for demonstration of general metadata mapping.",
+       manufacturer="imec",
+       model_number="NP2014",
+   )
+   general_metadata_nwbfile.add_device_model(general_metadata_device)
 
 **BIDS general metadata:**
 
-Depending on the modality, ``ecephys.json`` or ``icephys.json`` file contains metadata such as:
+Depending on the modality, the ``ecephys.json`` or ``icephys.json`` file contains metadata such as:
 
 .. code-block:: json
 
    {}
+
+**Mapping:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - NWB Field
+     - BIDS Field
+   * - ``nwbfile.institution``
+     - ``InstitutionName``
+    * - ??
+      - InstitutionAddress
+    * - ??
+      - InstitutionalDepartmentName
+    * - ??
+      - PowerLineFrequency
+    * - ``nwbfile.device[index].manufacturer``
+      - Manufacturer
 
 
 
@@ -210,8 +233,8 @@ The ``probes.tsv`` file contains a row for each probe:
 
 .. note::
 
-	The column order in all TSV files is strictly enforced by BIDS validation, and **nwb2bids** will make every
-	effort to produce valid files based on input data.
+   The column order in all TSV files is strictly enforced by BIDS validation, and **nwb2bids** will make every
+   effort to produce valid files based on input data.
 
 .. invisible-code-block: python
 
@@ -251,6 +274,7 @@ And the corresponding ``probes.json`` file provides detailed descriptions of eac
         - ``manufacturer``
       * - ``Device.description``
         - ``description``
+
 
 
 Ecephys Electrodes

--- a/docs/conversion_gallery.rst
+++ b/docs/conversion_gallery.rst
@@ -190,14 +190,14 @@ Depending on the modality, the ``ecephys.json`` or ``icephys.json`` file contain
      - BIDS Field
    * - ``nwbfile.institution``
      - ``InstitutionName``
-    * - ??
-      - InstitutionAddress
-    * - ??
-      - InstitutionalDepartmentName
-    * - ??
-      - PowerLineFrequency
-    * - ``nwbfile.device[index].manufacturer``
-      - Manufacturer
+   * - ??
+     - InstitutionAddress
+   * - ??
+     - InstitutionalDepartmentName
+   * - ??
+     - PowerLineFrequency
+   * - ``nwbfile.device[index].manufacturer``
+     - Manufacturer
 
 
 

--- a/docs/conversion_gallery.rst
+++ b/docs/conversion_gallery.rst
@@ -231,7 +231,7 @@ Depending on the modality, the ``ecephys.json`` or ``icephys.json`` file contain
            {
                 "SampleEnvironment": "ex-vivo",
                 "SampleEmbedding": "Epoxy resin",
-                "SliceThickness": "5",  # In microns
+                "SliceThickness": "5",  // In microns
                 "SampleExtractionProtocol": "Aliquot of primary motor cortex extracted from brain and embedded in epoxy resin."
            }
 

--- a/docs/conversion_gallery.rst
+++ b/docs/conversion_gallery.rst
@@ -206,7 +206,7 @@ Depending on the modality, the ``ecephys.json`` or ``icephys.json`` file contain
                 "BodyPartDetailsOntology": "http://purl.obolibrary.org/obo/UBERON_0001384"
            }
 
-    .. tab:: in vivo
+    .. tab:: *in vivo*
 
         .. code-block:: json
 
@@ -223,8 +223,7 @@ Depending on the modality, the ``ecephys.json`` or ``icephys.json`` file contain
                 "Instructions": "Mice were trained to stop running in response to air puffs."
            }
 
-.. tabs::
-    .. tab:: ex vivo
+    .. tab:: *ex vivo*
 
         .. code-block:: json
 

--- a/docs/conversion_gallery.rst
+++ b/docs/conversion_gallery.rst
@@ -206,7 +206,7 @@ Depending on the modality, the ``ecephys.json`` or ``icephys.json`` file contain
                 "BodyPartDetailsOntology": "http://purl.obolibrary.org/obo/UBERON_0001384"
            }
 
-    .. tab:: _in vivo_
+    .. tab:: in vivo
 
         .. code-block:: json
 
@@ -224,7 +224,7 @@ Depending on the modality, the ``ecephys.json`` or ``icephys.json`` file contain
            }
 
 .. tabs::
-    .. tab:: _ex vivo_
+    .. tab:: ex vivo
 
         .. code-block:: json
 

--- a/docs/conversion_gallery.rst
+++ b/docs/conversion_gallery.rst
@@ -162,10 +162,13 @@ particular subfields such as ``pynwb.DeviceModel``.
        session_start_time=datetime.datetime(1970, 1, 2, tzinfo=dateutil.tz.tzutc()),
        session_description="An example NWB file used for demonstration of general metadata mapping.",
        identifier=uuid.uuid4().hex,
-
+       institution="My Institution",
+       pharmacology="carprofen, 5 mg/kg, given peri-operatively and maintained during recording sessions to manage pain from the craniotomy/implant without sedation.",
+       protocol="Mice were placed in a running wheel and allowed to run freely while neural activity was recorded. Mice were trained to stop running in response to air puffs.",
+       slices="After the experiment, brains were extracted and sliced into 5 micron sections from primary motor cortex were fixed in epoxy resin for subsequent icephys study.",
    )
    general_metadata_device = pynwb.file.DeviceModel(
-       name="ExampleDevice",
+       name="GeneralMetadataDevice",
        description="This is an example device used for demonstration of general metadata mapping.",
        manufacturer="imec",
        model_number="NP2014",
@@ -176,11 +179,67 @@ particular subfields such as ``pynwb.DeviceModel``.
 
 Depending on the modality, the ``ecephys.json`` or ``icephys.json`` file contains metadata such as:
 
-.. code-block:: json
+.. tabs::
+    .. tab:: Common
 
-   {}
+        .. code-block:: json
+
+           {
+                "InstitutionName": "My Institution",
+                "InstitutionAddress": "123 Institution Rd, My City, My State, My Country",
+                "InstitutionalDepartmentName": "My Department",
+                "PowerLineFrequency": "60",  # In Hz
+                "Manufacturer": "imec",
+                "ManufacturersModelName": "NP",
+                "ManufacturersModelVersion": "2014",
+                "RecordingSetupName": "MyLabsRig",
+                "SamplingFrequency": 30000.0,  # In Hz
+                "DeviceSerialNumber": "ABC123",
+                "SoftwareName": "RecordingSoftware",
+                "SoftwareVersions": "1.0.0",
+                "RecordingDuration": "7200",  # In seconds
+                "RecordingType": "continuous",
+                "SoftwareFilters": {"Anti-aliasing filter": {"half-amplitude cutoff (Hz)": 500, "Roll-off": "6dB/Octave"}},
+                "HardwareFilters": {"Highpass RC filter": {"Half amplitude cutoff (Hz)": 0.0159, "Roll-off": "6dB/Octave"}},
+                "BodyPart": "BRAIN",
+                "BodyPartDetails": "primary motor cortex",
+                "BodyPartDetailsOntology": "http://purl.obolibrary.org/obo/UBERON_0001384"
+           }
+
+    .. tab:: _in vivo_
+
+        .. code-block:: json
+
+           {
+                "PharmaceuticalName": "carprofen",
+                "PharmaceuticalDoseAmount": 5,
+                "PharmaceuticalDoseUnits": "mg/kg",
+                "PharmaceuticalDoseRegimen": "Given peri-operatively and maintained during recording sessions to manage pain from the craniotomy/implant without sedation.",
+                "PharmaceuticalDoseTime": "0",  # In seconds
+                "SampleEnvironment": "in-vivo",
+                "SupplementarySignals": "Running wheel velocity.",
+                "TaskName": "My Running Task",
+                "TaskDescription": "Mice were placed in a running wheel and allowed to run freely while neural activity was recorded.",
+                "Instructions": "Mice were trained to stop running in response to air puffs."
+           }
+
+.. tabs::
+    .. tab:: _ex vivo_
+
+        .. code-block:: json
+
+           {
+                "SampleEnvironment": "ex-vivo",
+                "SampleEmbedding": "Epoxy resin",
+                "SliceThickness": "5",  # In microns
+                "SampleExtractionProtocol": "Aliquot of primary motor cortex extracted from brain and embedded in epoxy resin."
+           }
 
 **Mapping:**
+
+Currently, only one electrical series per NWB file is supported for automated metadata extraction.
+Additional sidecar files should be copied and modified to correspond to additional electrical series within the same NWB files.
+The use of `acq-[label]` suffixes in the other sidecar filenames is recommended to avoid confusion between series.
 
 .. list-table::
    :header-rows: 1
@@ -190,14 +249,130 @@ Depending on the modality, the ``ecephys.json`` or ``icephys.json`` file contain
      - BIDS Field
    * - ``nwbfile.institution``
      - ``InstitutionName``
-   * - ??
-     - InstitutionAddress
-   * - ??
-     - InstitutionalDepartmentName
-   * - ??
-     - PowerLineFrequency
-   * - ``nwbfile.device[index].manufacturer``
-     - Manufacturer
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``InstitutionAddress``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``InstitutionalDepartmentName``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``PowerLineFrequency``
+   * - ``nwbfile.acquisition.electrical_series[0].device_model.manufacturer``
+     - ``Manufacturer``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``ManufacturersModelName``
+   * - ``nwbfile.acquisition.electrical_series[0].device_model.model_number``
+     - ``ManufacturersModelVersion``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``RecordingSetupName``
+   * - ``nwbfile.acquisition.electrical_series[0].rate``
+     - ``SamplingFrequency``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``DeviceSerialNumber``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``SoftwareName``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``SoftwareVersions``
+   * - ``nwbfile.acquisition.electrical_series[0].data.shape[0] / nwbfile.acquisition.electrical_series[0].rate``
+     - ``RecordingDuration``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or comment on `Issue #337 <https://github.com/con/nwb2bids/issues/337>`_
+     - ``RecordingType``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``EpochLength``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``SoftwareFilters``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``HardwareFilters``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``PharmaceuticalName``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``PharmaceuticalDoseAmount``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``PharmaceuticalDoseUnits``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``PharmaceuticalDoseRegimen``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``PharmaceuticalDoseTime``
+   * - ``"BRAIN"`` if ``nwbfile.acquisition.electrical_series[0].electrode_group.location is not None``
+     - ``BodyPart``
+   * - ``nwbfile.acquisition.electrical_series[0].electrode_group.location``
+     - ``BodyPartDetails``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or comment on `Issue #338 <https://github.com/con/nwb2bids/issues/338>`_
+     - ``BodyPartDetailsOntology``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``SampleEnvironment``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``SampleEmbedding``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``SliceThickness``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``SampleExtractionProtocol``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``SupplementarySignals``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``TaskName``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``TaskDescription``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``Instructions``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``CogAtlasID``
+   * - | ~Not Yet Implemented~
+       | Please directly edit the file(s)
+       | or `Request This Feature <request-feature_>`_
+     - ``CogPOID``
 
 
 

--- a/docs/conversion_gallery.rst
+++ b/docs/conversion_gallery.rst
@@ -188,16 +188,16 @@ Depending on the modality, the ``ecephys.json`` or ``icephys.json`` file contain
                 "InstitutionName": "My Institution",
                 "InstitutionAddress": "123 Institution Rd, My City, My State, My Country",
                 "InstitutionalDepartmentName": "My Department",
-                "PowerLineFrequency": "60",  # In Hz
+                "PowerLineFrequency": "60",  // In Hz
                 "Manufacturer": "imec",
                 "ManufacturersModelName": "NP",
                 "ManufacturersModelVersion": "2014",
                 "RecordingSetupName": "MyLabsRig",
-                "SamplingFrequency": 30000.0,  # In Hz
+                "SamplingFrequency": 30000.0,  // In Hz
                 "DeviceSerialNumber": "ABC123",
                 "SoftwareName": "RecordingSoftware",
                 "SoftwareVersions": "1.0.0",
-                "RecordingDuration": "7200",  # In seconds
+                "RecordingDuration": "7200",  // In seconds
                 "RecordingType": "continuous",
                 "SoftwareFilters": {"Anti-aliasing filter": {"half-amplitude cutoff (Hz)": 500, "Roll-off": "6dB/Octave"}},
                 "HardwareFilters": {"Highpass RC filter": {"Half amplitude cutoff (Hz)": 0.0159, "Roll-off": "6dB/Octave"}},
@@ -215,7 +215,7 @@ Depending on the modality, the ``ecephys.json`` or ``icephys.json`` file contain
                 "PharmaceuticalDoseAmount": 5,
                 "PharmaceuticalDoseUnits": "mg/kg",
                 "PharmaceuticalDoseRegimen": "Given peri-operatively and maintained during recording sessions to manage pain from the craniotomy/implant without sedation.",
-                "PharmaceuticalDoseTime": "0",  # In seconds
+                "PharmaceuticalDoseTime": "0",  // In seconds
                 "SampleEnvironment": "in-vivo",
                 "SupplementarySignals": "Running wheel velocity.",
                 "TaskName": "My Running Task",

--- a/docs/expected_files/sub-001_ses-a_ecephys.json
+++ b/docs/expected_files/sub-001_ses-a_ecephys.json
@@ -1,0 +1,10 @@
+{
+    "PowerLineFrequency": "n/a",
+    "Manufacturer": "`nwb2bids` test suite",
+    "SamplingFrequency": 30000.0,
+    "RecordingDuration": 0.0003333333333333333,
+    "SoftwareFilters": "n/a",
+    "HardwareFilters": "n/a",
+    "BodyPart": "BRAIN",
+    "BodyPartDetails": "hippocampus"
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,7 +106,7 @@ Understanding the Standardization Landscape
 **nwb2bids** operates at the intersection of multiple neuroscience data standards.
 This section clarifies which standards are currently supported, which are planned for future implementation, and how they relate to the broader standardization ecosystem.
 
-For a comprehensive overview of neuroscience data standards and their relationships, see the `SfN 2025: "The Ecosystem of Standards in Neuroscience: Which Ones Are For You?" Poster <https://doi.org/10.5281/zenodo.18333007>`_ by Oliver Rübel *et al*.
+For a comprehensive overview of neuroscience data standards and their relationships, see the `SfN 2025: "The Ecosystem of Standards in Neuroscience: Which Ones Are For You?" Poster <https://zenodo.org/doi/10.5281/zenodo.18333007>`_ by Oliver Rübel *et al*.
 
 Currently Supported Standards
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -81,6 +81,7 @@ To convert a single NWB file to BIDS dataset structure, we run the following com
                 "directories": set(),
                 "files": {
                     "sub-001_ses-A_ecephys.nwb",
+                    "sub-001_ses-A_ecephys.json",
                     "sub-001_ses-A_channels.tsv",
                     "sub-001_ses-A_channels.json",
                     "sub-001_ses-A_electrodes.tsv",
@@ -112,6 +113,7 @@ along the lines of:
         └── ses-A/
             └── ecephys/
                 ├── sub-001_ses-A_ecephys.nwb
+                ├── sub-001_ses-A_ecephys.json
                 ├── sub-001_ses-A_channels.tsv
                 ├── sub-001_ses-A_channels.json
                 ├── sub-001_ses-A_electrodes.tsv
@@ -177,6 +179,7 @@ To convert all of the NWB files under a directory to BIDS, we can run the follow
                 "directories": set(),
                 "files": {
                     "sub-001_ses-A_ecephys.nwb",
+                    "sub-001_ses-A_ecephys.json",
                     "sub-001_ses-A_channels.tsv",
                     "sub-001_ses-A_channels.json",
                     "sub-001_ses-A_electrodes.tsv",
@@ -193,6 +196,7 @@ To convert all of the NWB files under a directory to BIDS, we can run the follow
                 "directories": set(),
                 "files": {
                     "sub-001_ses-B_ecephys.nwb",
+                    "sub-001_ses-B_ecephys.json",
                     "sub-001_ses-B_channels.tsv",
                     "sub-001_ses-B_channels.json",
                     "sub-001_ses-B_electrodes.tsv",
@@ -220,6 +224,7 @@ And our BIDS dataset should look like:
         ├── ses-A/
         │   └── ecephys/
         │       ├── sub-001_ses-A_ecephys.nwb
+        │       ├── sub-001_ses-A_ecephys.json
         │       ├── sub-001_ses-A_channels.tsv
         │       ├── sub-001_ses-A_channels.json
         │       ├── sub-001_ses-A_electrodes.tsv
@@ -229,6 +234,7 @@ And our BIDS dataset should look like:
         └── ses-B/
             └── ecephys/
                 ├── sub-001_ses-B_ecephys.nwb
+                ├── sub-001_ses-B_ecephys.json
                 ├── sub-001_ses-B_channels.tsv
                 ├── sub-001_ses-B_channels.json
                 ├── sub-001_ses-B_electrodes.tsv
@@ -337,6 +343,7 @@ We can select which files and directories to convert like so:
                 "directories": set(),
                 "files": {
                     "sub-001_ses-A_ecephys.nwb",
+                    "sub-001_ses-A_ecephys.json",
                     "sub-001_ses-A_channels.tsv",
                     "sub-001_ses-A_channels.json",
                     "sub-001_ses-A_electrodes.tsv",
@@ -353,6 +360,7 @@ We can select which files and directories to convert like so:
                 "directories": set(),
                 "files": {
                     "sub-001_ses-B_ecephys.nwb",
+                    "sub-001_ses-B_ecephys.json",
                     "sub-001_ses-B_channels.tsv",
                     "sub-001_ses-B_channels.json",
                     "sub-001_ses-B_electrodes.tsv",
@@ -373,6 +381,7 @@ We can select which files and directories to convert like so:
                 "directories": set(),
                 "files": {
                     "sub-002_ses-C_ecephys.nwb",
+                    "sub-002_ses-C_ecephys.json",
                     "sub-002_ses-C_channels.tsv",
                     "sub-002_ses-C_channels.json",
                     "sub-002_ses-C_electrodes.tsv",
@@ -400,6 +409,7 @@ Our resulting BIDS dataset should now contain all three NWB files converted to B
     │   ├── ses-A/
     │   │   └── ecephys/
     │   │       ├── sub-001_ses-A_ecephys.nwb
+    │   │       ├── sub-001_ses-A_ecephys.json
     │   │       ├── sub-001_ses-A_channels.tsv
     │   │       ├── sub-001_ses-A_channels.json
     │   │       ├── sub-001_ses-A_electrodes.tsv
@@ -409,6 +419,7 @@ Our resulting BIDS dataset should now contain all three NWB files converted to B
     │   └── ses-B/
     │       └── ecephys/
     │           ├── sub-001_ses-B_ecephys.nwb
+    │           ├── sub-001_ses-B_ecephys.json
     │           ├── sub-001_ses-B_channels.tsv
     │           ├── sub-001_ses-B_channels.json
     │           ├── sub-001_ses-B_electrodes.tsv
@@ -421,6 +432,7 @@ Our resulting BIDS dataset should now contain all three NWB files converted to B
         └── ses-C/
             └── ecephys/
                 ├── sub-002_ses-C_ecephys.nwb
+                ├── sub-002_ses-C_ecephys.json
                 ├── sub-002_ses-C_channels.tsv
                 ├── sub-002_ses-C_channels.json
                 ├── sub-002_ses-C_electrodes.tsv
@@ -496,6 +508,7 @@ To test this out, we can create a new empty directory and navigate into it befor
                 "directories": set(),
                 "files": {
                     "sub-001_ses-A_ecephys.nwb",
+                    "sub-001_ses-A_ecephys.json",
                     "sub-001_ses-A_channels.tsv",
                     "sub-001_ses-A_channels.json",
                     "sub-001_ses-A_electrodes.tsv",
@@ -512,6 +525,7 @@ To test this out, we can create a new empty directory and navigate into it befor
                 "directories": set(),
                 "files": {
                     "sub-001_ses-B_ecephys.nwb",
+                    "sub-001_ses-B_ecephys.json",
                     "sub-001_ses-B_channels.tsv",
                     "sub-001_ses-B_channels.json",
                     "sub-001_ses-B_electrodes.tsv",
@@ -532,6 +546,7 @@ To test this out, we can create a new empty directory and navigate into it befor
                 "directories": set(),
                 "files": {
                     "sub-002_ses-C_ecephys.nwb",
+                    "sub-002_ses-C_ecephys.json",
                     "sub-002_ses-C_channels.tsv",
                     "sub-002_ses-C_channels.json",
                     "sub-002_ses-C_electrodes.tsv",
@@ -651,6 +666,7 @@ To include this additional metadata during conversion, we can use the following 
                 "directories": set(),
                 "files": {
                     "sub-001_ses-A_ecephys.nwb",
+                    "sub-001_ses-A_ecephys.json",
                     "sub-001_ses-A_channels.tsv",
                     "sub-001_ses-A_channels.json",
                     "sub-001_ses-A_electrodes.tsv",
@@ -724,6 +740,7 @@ broken down into the following distinct steps:
             "directories": set(),
             "files": {
                 "sub-001_ses-A_ecephys.nwb",
+                "sub-001_ses-A_ecephys.json",
                 "sub-001_ses-A_channels.tsv",
                 "sub-001_ses-A_channels.json",
                 "sub-001_ses-A_electrodes.tsv",

--- a/src/nwb2bids/_converters/_session_converter.py
+++ b/src/nwb2bids/_converters/_session_converter.py
@@ -195,6 +195,10 @@ class SessionConverter(BaseConverter):
         file_prefix = f"sub-{participant_id}_ses-{session_id}"
 
         modality_directory = self._establish_modality_subdirectory()
+
+        modality = modality_directory.name
+        general_metadata_file_path = modality_directory / f"{file_prefix}_{modality}.json"
+        self.session_metadata.general_metadata.to_json(file_path=general_metadata_file_path)
         if self.session_metadata.probe_table is not None:
             probes_tsv_file_path = modality_directory / f"{file_prefix}_probes.tsv"
             self.session_metadata.probe_table.to_tsv(file_path=probes_tsv_file_path)

--- a/src/nwb2bids/bids_models/__init__.py
+++ b/src/nwb2bids/bids_models/__init__.py
@@ -3,6 +3,7 @@ from ._dataset_description import DatasetDescription
 from ._probes import ProbeTable, Probe
 from ._electrodes import Electrode, ElectrodeTable
 from ._channels import Channel, ChannelTable
+from ._general_metadata import GeneralMetadata
 
 __all__ = [
     "BidsSessionMetadata",
@@ -11,6 +12,7 @@ __all__ = [
     "DatasetDescription",
     "Electrode",
     "ElectrodeTable",
+    "GeneralMetadata",
     "Participant",
     "Probe" "ProbeTable",
 ]

--- a/src/nwb2bids/bids_models/_bids_session_metadata.py
+++ b/src/nwb2bids/bids_models/_bids_session_metadata.py
@@ -11,6 +11,7 @@ from ._base_metadata_model import BaseMetadataContainerModel
 from ._channels import ChannelTable
 from ._electrodes import ElectrodeTable
 from ._events import Events
+from ._general_metadata import GeneralMetadata
 from ._model_globals import _VALID_ID_REGEX
 from ._participant import Participant
 from ._probes import ProbeTable
@@ -18,7 +19,7 @@ from .._converters._run_config import RunConfig
 from .._tools import cache_read_nwb
 from ..notifications import Notification
 from ..sanitization import Sanitization
-from ._general_metadata import GeneralMetadata
+
 
 class BidsSessionMetadata(BaseMetadataContainerModel):
     """
@@ -99,6 +100,7 @@ class BidsSessionMetadata(BaseMetadataContainerModel):
         session_id = next(iter(session_ids))
 
         participant = Participant.from_nwbfiles(nwbfiles=nwbfiles)
+        general_metadata = GeneralMetadata.from_nwbfiles(nwbfiles=nwbfiles)
         events = Events.from_nwbfiles(nwbfiles=nwbfiles)
         probe_table = ProbeTable.from_nwbfiles(nwbfiles=nwbfiles)
         electrode_table = ElectrodeTable.from_nwbfiles(nwbfiles=nwbfiles)
@@ -107,6 +109,7 @@ class BidsSessionMetadata(BaseMetadataContainerModel):
         dictionary = {
             "session_id": session_id,
             "participant": participant,
+            "general_metadata": general_metadata,
             "run_config": run_config,
         }
         if events is not None:

--- a/src/nwb2bids/bids_models/_bids_session_metadata.py
+++ b/src/nwb2bids/bids_models/_bids_session_metadata.py
@@ -18,7 +18,7 @@ from .._converters._run_config import RunConfig
 from .._tools import cache_read_nwb
 from ..notifications import Notification
 from ..sanitization import Sanitization
-
+from ._general_metadata import GeneralMetadata
 
 class BidsSessionMetadata(BaseMetadataContainerModel):
     """
@@ -27,6 +27,7 @@ class BidsSessionMetadata(BaseMetadataContainerModel):
 
     session_id: str | None = pydantic.Field(description="A unique session identifier.", default=None)
     participant: Participant = pydantic.Field(description="Metadata about a participant used in this experiment.")
+    general_metadata: GeneralMetadata = pydantic.Field(description="General metadata about the experiment.")
     events: Events | None = pydantic.Field(
         description="Timing data and metadata regarding events that occur during this experiment.", default=None
     )

--- a/src/nwb2bids/bids_models/_channels.py
+++ b/src/nwb2bids/bids_models/_channels.py
@@ -68,10 +68,10 @@ class Channel(BaseMetadataModel):
         title="Units",
         default="V",
     )
-    sampling_frequency: float | None = pydantic.Field(
+    sampling_frequency: float = pydantic.Field(
         description="Sampling rate of the channel in Hz.",
         title="Sampling frequency",
-        default=None,
+        default=-1.0,
     )
     low_cutoff: float | None = pydantic.Field(
         description=(

--- a/src/nwb2bids/bids_models/_channels.py
+++ b/src/nwb2bids/bids_models/_channels.py
@@ -227,7 +227,7 @@ class ChannelTable(BaseMetadataContainerModel):
         modality = "ecephys" if has_ecephys_electrodes else "icephys"
         if modality == "ecephys":
             # Only scan electrical series listed under acquisition since those under processing can downsample the rate
-            sampling_frequency = None
+            sampling_frequency = -1.0
             stream_id = None
             gain = None
             raw_electrical_series = [

--- a/src/nwb2bids/bids_models/_general_metadata.py
+++ b/src/nwb2bids/bids_models/_general_metadata.py
@@ -228,7 +228,7 @@ class GeneralMetadata(pydantic.BaseModel):
 
     @classmethod
     @pydantic.validate_call
-    def from_nwbfiles(cls, nwbfiles: list[pynwb.NWBFile]) -> typing_extensions.Self:
+    def from_nwbfiles(cls, nwbfiles: list[pydantic.InstanceOf[pynwb.NWBFile]]) -> typing_extensions.Self:
         """
         Extracts all unique general metadata from the in-memory NWBFile objects.
         """

--- a/src/nwb2bids/bids_models/_general_metadata.py
+++ b/src/nwb2bids/bids_models/_general_metadata.py
@@ -1,53 +1,251 @@
-# import json
-# import typing
+import json
+import typing
 
-# import pydantic
-# import pynwb
-#
-#
-# class EcephysMetadata(pydantic.BaseModel):
-#     """
-#     General device and session metadata extracted from NWB files.
-#
-#     While NWB treats this information as high-level session-specific metadata, BIDS treats these fields as
-#     modality specific and as pertaining to 'parameters' that can vary.
-#
-#     This should typically be written to two files:
-#       - `acq-general_ecephys.json`
-#       - `acq-
-#     """
-#
-#     InstitutionName: str = pydantic.Field(
-#         description="The name of the institution in charge of the equipment that produced the measurements."
-#     )
-#
-#     model_config = pydantic.ConfigDict(
-#         validate_assignment=True,  # Re-validate model on mutation
-#         extra="allow",  # Allow additional custom fields
-#     )
-#
-#     @classmethod
-#     @pydantic.validate_call
-#     def from_nwbfiles(cls, nwbfiles: list[pynwb.NWBFile]) -> typing_extensions.Self:
-#         """
-#         Extracts all unique general metadata from the in-memory NWBFile objects.
-#         """
-#         institution_names = {nwbfile.institution for nwbfile in nwbfiles if nwbfile.institution is not None}
-#
-#         general_metadata = cls(
-#             InstitutionName=institution_names,
-#         )
-#         return subject
-#
-#     @pydantic.validate_call
-#     def to_json(self, file_path: str | pathlib.Path) -> None:
-#         """
-#         Save the general metadata to a JSON file.
-#
-#         Parameters
-#         ----------
-#         file_path : str or pathlib.Path
-#             The path to the file where the metadata will be saved.
-#         """
-#         with file_path.open(mode="w") as file_stream:
-#             json.dump(obj=self.model_dump(), fp=file_stream, indent=4)
+import pydantic
+import pynwb
+
+
+class GeneralMetadata(pydantic.BaseModel):
+    """
+    General device and session metadata extracted from NWB files.
+
+    While NWB treats this information as high-level session-specific metadata, BIDS treats these fields as
+    modality specific and as pertaining to 'parameters' that can vary.
+
+    This should typically be written to two files, depending on the modality:
+      - `_ecephys.json`
+      - `_icephys.json`
+    """
+
+    InstitutionName: str | None = pydantic.Field(
+        description="The name of the institution in charge of the equipment that produced the measurements.",
+        default=None,
+    )
+    InstitutionAddress: str | None= pydantic.Field(
+        description="The address of the institution in charge of the equipment that produced the measurements.",
+        default=None,
+    )
+    InstitutionalDepartmentName: str | None= pydantic.Field(
+        description="The department in the institution in charge of the equipment that produced the measurements.",
+        default=None,
+    )
+    PowerLineFrequency: float | typing.Literal["n/a"] = pydantic.Field(
+        description=(
+            "Frequency (in Hz) of the power grid at the geographical location of the "
+            "instrument (for example, 50 or 60)."
+        ),
+        default="n/a",
+    )
+    Manufacturer: str | None = pydantic.Field(
+        description='Manufacturer of the equipment that produced the measurements. For example, "TDT", "Blackrock".',
+        default=None,
+    )
+    ManufacturersModelName: str | None = pydantic.Field(
+        description="Manufacturer's model name of the equipment that produced the measurements.",
+        default=None,
+    )
+    ManufacturersModelVersion: str | None = pydantic.Field(
+        description="Manufacturer's model version of the equipment that produced the measurements.",
+        default=None,
+    )
+    RecordingSetupName: str | None= pydantic.Field(
+        description="Custom name of the recording setup.",
+        default=None,
+    )
+    SamplingFrequency: float = pydantic.Field(
+        description=(
+            'Sampling frequency (in Hz) of all the data in the recording, regardless of their type '
+            '(for example, 2400). Internal (maximum) sampling frequency (in Hz) of the recording '
+            '(for example, "24000").'
+        ),
+        default=None,
+    )
+    DeviceSerialNumber: str = pydantic.Field(
+        description=(
+            "The serial number of the equipment that produced the measurements. A pseudonym can also be used to "
+            "prevent the equipment from being identifiable, so long as each pseudonym is unique within the dataset. "
+            "The serial number of the components of the setup, RECOMMENDED to add serial numbers and versions of ALL "
+            "components constituting the setup."
+        ),
+        default=None,
+    )
+    SoftwareName: str = pydantic.Field(
+        description=(
+            "Name of the software that was used to present the stimuli. "
+            "The name of the software suite used to record the data."
+        ),
+        default=None,
+    )
+    SoftwareVersions: str = pydantic.Field(
+        description="Manufacturer's designation of software version of the equipment that produced the measurements.",
+        default=None,
+    )
+    RecordingDuration: float = pydantic.Field(
+        description="Length of the recording in seconds (for example, 3600).",
+        default=None,
+    )
+    RecordingType: str = pydantic.Field(
+        description=(
+            'Defines whether the recording is "continuous", "discontinuous", or "epoched", where "epoched" is limited '
+            'to time windows about events of interest (for example, stimulus presentations or subject responses). '
+            'Must be one of: "continuous", "epoched", "discontinuous".'
+        ),
+        default=None,
+    )
+    EpochLength: float | None = pydantic.Field(
+        description=(
+            "Duration of individual epochs in seconds (for example, 1) in case of epoched data. If recording was "
+            "continuous or discontinuous, leave out the field. Must be a number greater than or equal to 0."
+        ),
+        default=None,
+    )
+    SoftwareFilters: dict[str,dict[str, typing.Any]] | typing.Literal["n/a"] = pydantic.Field(
+        description=(
+            'Object of temporal software filters applied, or "n/a" if the data is not available.Each key-value pair '
+            'in the JSON object is a name of the filter and an object in which its parameters are defined as '
+            'key-value pairs ( for example, '
+            '{"Anti-aliasing filter": {"half-amplitude cutoff (Hz)": 500, "Roll-off": "6dB/Octave"}}).'
+        ),
+        default="n/a",
+    )
+    HardwareFilters	: dict[str,dict[str, typing.Any]] | typing.Literal["n/a"] = pydantic.Field(
+        description=(
+            'Object of temporal hardware filters applied, or "n/a" if the data is not available. Each key-value pair '
+            'in the JSON object is a name of the filter and an object in which its parameters are defined as '
+            'key-value pairs. For example, '
+            '{"Highpass RC filter": {"Half amplitude cutoff (Hz)": 0.0159, "Roll-off": "6dB/Octave"}}.'
+        ),
+        default="n/a",
+    )
+    PharmaceuticalName: str | None = pydantic.Field(
+        description="Name of pharmaceutical.",
+        default=None,
+    )
+    PharmaceuticalDoseAmount: float | list[float] | None = pydantic.Field(
+        description="Dose amount of administered pharmaceutical.",
+        default=None,
+    )
+    PharmaceuticalDoseUnits: str | None = pydantic.Field(
+        description='Unit format relating to pharmaceutical dose (for example, "mg" or "mg/kg").',
+        default=None,
+    )
+    PharmaceuticalDoseRegimen: str | None = pydantic.Field(
+        description=(
+            'Details of the pharmaceutical dose regimen. Either adequate description or short-code relating to '
+            'regimen documented elsewhere (for example, "single oral bolus").'
+        ),
+        default=None,
+    )
+    PharmaceuticalDoseTime: float | list[float] | None = pydantic.Field(
+        description=(
+            'Time of administration of pharmaceutical dose, relative to time zero. For an infusion, this should be a '
+            'vector with two elements specifying the start and end of the infusion period. For more complex dose '
+            'regimens, the regimen description should be complete enough to enable unambiguous interpretation of '
+            '"PharmaceuticalDoseTime". Unit format of the specified pharmaceutical dose time MUST be seconds.'
+        ),
+        default=None,
+    )
+    BodyPart: float | None = pydantic.Field(
+        description="Body part of the organ / body region scanned.",
+        default=None,
+    )
+    BodyPartDetails: float | None = pydantic.Field(
+        description='Additional details about body part or location (for example: "corpus callosum").',
+        default=None,
+    )
+    BodyPartDetailsOntology: float | None = pydantic.Field(
+        description=(
+            'URI of ontology used for BodyPartDetails (for example: "https://www.ebi.ac.uk/ols/ontologies/uberon").'
+        ),
+        default=None,
+    )
+    SampleEnvironment: float | None = pydantic.Field(
+        description=(
+            'Environment in which the sample was imaged. MUST be one of: "in vivo", "ex vivo" or "in vitro". '
+            'Must be one of: "in vivo", "ex vivo", "in vitro".'
+        ),
+        default=None,
+    )
+    SampleEmbedding: float | None = pydantic.Field(
+        description='Description of the tissue sample embedding (for example: "Epoxy resin").',
+        default=None,
+    )
+    SliceThickness: float | None = pydantic.Field(
+        description=(
+            'Slice thickness of the tissue sample in the unit micrometers ("um") (for example: 5). '
+            'Must be a number greater than 0.'
+        ),
+        default=None,
+    )
+    SampleExtractionProtocol: float | None = pydantic.Field(
+        description="Description of the sample extraction protocol or URI (for example from protocols.io).",
+        default=None,
+    )
+    SupplementarySignals: str | None = pydantic.Field(
+        description=(
+            "Description of the supplementary signal (additional modalities) recorded in parallel and are "
+            "also stored in the data file."
+        ),
+        default=None,
+    )
+    TaskName: str | None = pydantic.Field(
+        description=(
+            '	Name of the task. No two tasks should have the same name. The task label included in the filename '
+            'MAY be derived from this "TaskName" field by removing all non-alphanumeric or + characters (that is, '
+            'all except those matching [0-9a-zA-Z+]), and potentially replacing spaces with + to ease readability. '
+            'For example "TaskName" "faces n-back" or "head nodding" could correspond to task labels faces+n+back '
+            'or facesnback and head+nodding or headnodding, respectively. A RECOMMENDED convention is to name '
+            'resting state task using labels beginning with rest.'
+        ),
+        default=None,
+    )
+    TaskDescription: str | None = pydantic.Field(
+        description="Longer description of the task.",
+        default=None,
+    )
+    Instructions: str | None = pydantic.Field(
+        description=(
+            "Text of the instructions given to participants before the recording. This is especially important in "
+            "context of resting state recordings and distinguishing between eyes open and eyes closed paradigms."
+        ),
+        default=None,
+    )
+    CogAtlasID: str | None = pydantic.Field(
+        description="URI of the corresponding Cognitive Atlas Task term.",
+        default=None,
+    )
+    CogPOID: str | None = pydantic.Field(
+        description="URI of the corresponding CogPO term.",
+        default=None,
+    )
+
+    model_config = pydantic.ConfigDict(
+        validate_assignment=True,  # Re-validate model on mutation
+        extra="allow",  # Allow additional custom fields
+    )
+
+    @classmethod
+    @pydantic.validate_call
+    def from_nwbfiles(cls, nwbfiles: list[pynwb.NWBFile]) -> typing_extensions.Self:
+        """
+        Extracts all unique general metadata from the in-memory NWBFile objects.
+        """
+        institution_names = {nwbfile.institution for nwbfile in nwbfiles if nwbfile.institution is not None}
+
+        general_metadata = cls(
+            InstitutionName=institution_names,
+        )
+        return subject
+
+    @pydantic.validate_call
+    def to_json(self, file_path: str | pathlib.Path) -> None:
+        """
+        Save the general metadata to a JSON file.
+
+        Parameters
+        ----------
+        file_path : str or pathlib.Path
+            The path to the file where the metadata will be saved.
+        """
+        with file_path.open(mode="w") as file_stream:
+            json.dump(obj=self.model_dump(), fp=file_stream, indent=4)

--- a/src/nwb2bids/bids_models/_general_metadata.py
+++ b/src/nwb2bids/bids_models/_general_metadata.py
@@ -1,8 +1,10 @@
 import json
+import pathlib
 import typing
 
 import pydantic
 import pynwb
+import typing_extensions
 
 
 class GeneralMetadata(pydantic.BaseModel):
@@ -21,11 +23,11 @@ class GeneralMetadata(pydantic.BaseModel):
         description="The name of the institution in charge of the equipment that produced the measurements.",
         default=None,
     )
-    InstitutionAddress: str | None= pydantic.Field(
+    InstitutionAddress: str | None = pydantic.Field(
         description="The address of the institution in charge of the equipment that produced the measurements.",
         default=None,
     )
-    InstitutionalDepartmentName: str | None= pydantic.Field(
+    InstitutionalDepartmentName: str | None = pydantic.Field(
         description="The department in the institution in charge of the equipment that produced the measurements.",
         default=None,
     )
@@ -48,19 +50,19 @@ class GeneralMetadata(pydantic.BaseModel):
         description="Manufacturer's model version of the equipment that produced the measurements.",
         default=None,
     )
-    RecordingSetupName: str | None= pydantic.Field(
+    RecordingSetupName: str | None = pydantic.Field(
         description="Custom name of the recording setup.",
         default=None,
     )
-    SamplingFrequency: float = pydantic.Field(
+    SamplingFrequency: float | typing.Literal["n/a"] = pydantic.Field(
         description=(
-            'Sampling frequency (in Hz) of all the data in the recording, regardless of their type '
-            '(for example, 2400). Internal (maximum) sampling frequency (in Hz) of the recording '
+            "Sampling frequency (in Hz) of all the data in the recording, regardless of their type "
+            "(for example, 2400). Internal (maximum) sampling frequency (in Hz) of the recording "
             '(for example, "24000").'
         ),
-        default=None,
+        default="n/a",
     )
-    DeviceSerialNumber: str = pydantic.Field(
+    DeviceSerialNumber: str | None = pydantic.Field(
         description=(
             "The serial number of the equipment that produced the measurements. A pseudonym can also be used to "
             "prevent the equipment from being identifiable, so long as each pseudonym is unique within the dataset. "
@@ -69,25 +71,25 @@ class GeneralMetadata(pydantic.BaseModel):
         ),
         default=None,
     )
-    SoftwareName: str = pydantic.Field(
+    SoftwareName: str | None = pydantic.Field(
         description=(
             "Name of the software that was used to present the stimuli. "
             "The name of the software suite used to record the data."
         ),
         default=None,
     )
-    SoftwareVersions: str = pydantic.Field(
+    SoftwareVersions: str | None = pydantic.Field(
         description="Manufacturer's designation of software version of the equipment that produced the measurements.",
         default=None,
     )
-    RecordingDuration: float = pydantic.Field(
+    RecordingDuration: float | None = pydantic.Field(
         description="Length of the recording in seconds (for example, 3600).",
         default=None,
     )
-    RecordingType: str = pydantic.Field(
+    RecordingType: str | None = pydantic.Field(
         description=(
             'Defines whether the recording is "continuous", "discontinuous", or "epoched", where "epoched" is limited '
-            'to time windows about events of interest (for example, stimulus presentations or subject responses). '
+            "to time windows about events of interest (for example, stimulus presentations or subject responses). "
             'Must be one of: "continuous", "epoched", "discontinuous".'
         ),
         default=None,
@@ -99,20 +101,20 @@ class GeneralMetadata(pydantic.BaseModel):
         ),
         default=None,
     )
-    SoftwareFilters: dict[str,dict[str, typing.Any]] | typing.Literal["n/a"] = pydantic.Field(
+    SoftwareFilters: dict[str, dict[str, typing.Any]] | typing.Literal["n/a"] = pydantic.Field(
         description=(
             'Object of temporal software filters applied, or "n/a" if the data is not available.Each key-value pair '
-            'in the JSON object is a name of the filter and an object in which its parameters are defined as '
-            'key-value pairs ( for example, '
+            "in the JSON object is a name of the filter and an object in which its parameters are defined as "
+            "key-value pairs ( for example, "
             '{"Anti-aliasing filter": {"half-amplitude cutoff (Hz)": 500, "Roll-off": "6dB/Octave"}}).'
         ),
         default="n/a",
     )
-    HardwareFilters	: dict[str,dict[str, typing.Any]] | typing.Literal["n/a"] = pydantic.Field(
+    HardwareFilters: dict[str, dict[str, typing.Any]] | typing.Literal["n/a"] = pydantic.Field(
         description=(
             'Object of temporal hardware filters applied, or "n/a" if the data is not available. Each key-value pair '
-            'in the JSON object is a name of the filter and an object in which its parameters are defined as '
-            'key-value pairs. For example, '
+            "in the JSON object is a name of the filter and an object in which its parameters are defined as "
+            "key-value pairs. For example, "
             '{"Highpass RC filter": {"Half amplitude cutoff (Hz)": 0.0159, "Roll-off": "6dB/Octave"}}.'
         ),
         default="n/a",
@@ -131,16 +133,16 @@ class GeneralMetadata(pydantic.BaseModel):
     )
     PharmaceuticalDoseRegimen: str | None = pydantic.Field(
         description=(
-            'Details of the pharmaceutical dose regimen. Either adequate description or short-code relating to '
+            "Details of the pharmaceutical dose regimen. Either adequate description or short-code relating to "
             'regimen documented elsewhere (for example, "single oral bolus").'
         ),
         default=None,
     )
     PharmaceuticalDoseTime: float | list[float] | None = pydantic.Field(
         description=(
-            'Time of administration of pharmaceutical dose, relative to time zero. For an infusion, this should be a '
-            'vector with two elements specifying the start and end of the infusion period. For more complex dose '
-            'regimens, the regimen description should be complete enough to enable unambiguous interpretation of '
+            "Time of administration of pharmaceutical dose, relative to time zero. For an infusion, this should be a "
+            "vector with two elements specifying the start and end of the infusion period. For more complex dose "
+            "regimens, the regimen description should be complete enough to enable unambiguous interpretation of "
             '"PharmaceuticalDoseTime". Unit format of the specified pharmaceutical dose time MUST be seconds.'
         ),
         default=None,
@@ -173,7 +175,7 @@ class GeneralMetadata(pydantic.BaseModel):
     SliceThickness: float | None = pydantic.Field(
         description=(
             'Slice thickness of the tissue sample in the unit micrometers ("um") (for example: 5). '
-            'Must be a number greater than 0.'
+            "Must be a number greater than 0."
         ),
         default=None,
     )
@@ -190,12 +192,12 @@ class GeneralMetadata(pydantic.BaseModel):
     )
     TaskName: str | None = pydantic.Field(
         description=(
-            '	Name of the task. No two tasks should have the same name. The task label included in the filename '
+            "	Name of the task. No two tasks should have the same name. The task label included in the filename "
             'MAY be derived from this "TaskName" field by removing all non-alphanumeric or + characters (that is, '
-            'all except those matching [0-9a-zA-Z+]), and potentially replacing spaces with + to ease readability. '
+            "all except those matching [0-9a-zA-Z+]), and potentially replacing spaces with + to ease readability. "
             'For example "TaskName" "faces n-back" or "head nodding" could correspond to task labels faces+n+back '
-            'or facesnback and head+nodding or headnodding, respectively. A RECOMMENDED convention is to name '
-            'resting state task using labels beginning with rest.'
+            "or facesnback and head+nodding or headnodding, respectively. A RECOMMENDED convention is to name "
+            "resting state task using labels beginning with rest."
         ),
         default=None,
     )
@@ -230,12 +232,17 @@ class GeneralMetadata(pydantic.BaseModel):
         """
         Extracts all unique general metadata from the in-memory NWBFile objects.
         """
-        institution_names = {nwbfile.institution for nwbfile in nwbfiles if nwbfile.institution is not None}
+        if len(nwbfiles) > 1:
+            message = "Conversion of multiple NWB files per session is not yet supported."
+            raise NotImplementedError(message)
+        # nwbfile = nwbfiles[0]
 
-        general_metadata = cls(
-            InstitutionName=institution_names,
-        )
-        return subject
+        dictionary: dict[str, str] = dict()
+
+        # TODO
+
+        general_metadata = cls(**dictionary)
+        return general_metadata
 
     @pydantic.validate_call
     def to_json(self, file_path: str | pathlib.Path) -> None:
@@ -247,5 +254,5 @@ class GeneralMetadata(pydantic.BaseModel):
         file_path : str or pathlib.Path
             The path to the file where the metadata will be saved.
         """
-        with file_path.open(mode="w") as file_stream:
+        with pathlib.Path(file_path).open(mode="w") as file_stream:
             json.dump(obj=self.model_dump(), fp=file_stream, indent=4)

--- a/src/nwb2bids/bids_models/_general_metadata.py
+++ b/src/nwb2bids/bids_models/_general_metadata.py
@@ -237,7 +237,7 @@ class GeneralMetadata(pydantic.BaseModel):
             raise NotImplementedError(message)
         nwbfile = nwbfiles[0]
 
-        dictionary: dict[str, str] = {
+        dictionary: dict[str, str | int | float | None] = {
             "PowerLineFrequency": "n/a",
             "SamplingFrequency": "n/a",
             "SoftwareFilters": "n/a",

--- a/src/nwb2bids/bids_models/_general_metadata.py
+++ b/src/nwb2bids/bids_models/_general_metadata.py
@@ -54,13 +54,13 @@ class GeneralMetadata(pydantic.BaseModel):
         description="Custom name of the recording setup.",
         default=None,
     )
-    SamplingFrequency: float | typing.Literal["n/a"] = pydantic.Field(
+    SamplingFrequency: float = pydantic.Field(
         description=(
             "Sampling frequency (in Hz) of all the data in the recording, regardless of their type "
             "(for example, 2400). Internal (maximum) sampling frequency (in Hz) of the recording "
             '(for example, "24000").'
         ),
-        default="n/a",
+        default=-1.0,
     )
     DeviceSerialNumber: str | None = pydantic.Field(
         description=(

--- a/src/nwb2bids/bids_models/_general_metadata.py
+++ b/src/nwb2bids/bids_models/_general_metadata.py
@@ -103,7 +103,7 @@ class GeneralMetadata(pydantic.BaseModel):
     )
     SoftwareFilters: dict[str, dict[str, typing.Any]] | typing.Literal["n/a"] = pydantic.Field(
         description=(
-            'Object of temporal software filters applied, or "n/a" if the data is not available.Each key-value pair '
+            'Object of temporal software filters applied, or "n/a" if the data is not available. Each key-value pair '
             "in the JSON object is a name of the filter and an object in which its parameters are defined as "
             "key-value pairs ( for example, "
             '{"Anti-aliasing filter": {"half-amplitude cutoff (Hz)": 500, "Roll-off": "6dB/Octave"}}).'
@@ -192,7 +192,7 @@ class GeneralMetadata(pydantic.BaseModel):
     )
     TaskName: str | None = pydantic.Field(
         description=(
-            "	Name of the task. No two tasks should have the same name. The task label included in the filename "
+            "Name of the task. No two tasks should have the same name. The task label included in the filename "
             'MAY be derived from this "TaskName" field by removing all non-alphanumeric or + characters (that is, '
             "all except those matching [0-9a-zA-Z+]), and potentially replacing spaces with + to ease readability. "
             'For example "TaskName" "faces n-back" or "head nodding" could correspond to task labels faces+n+back '

--- a/src/nwb2bids/bids_models/_general_metadata.py
+++ b/src/nwb2bids/bids_models/_general_metadata.py
@@ -235,11 +235,37 @@ class GeneralMetadata(pydantic.BaseModel):
         if len(nwbfiles) > 1:
             message = "Conversion of multiple NWB files per session is not yet supported."
             raise NotImplementedError(message)
-        # nwbfile = nwbfiles[0]
+        nwbfile = nwbfiles[0]
 
-        dictionary: dict[str, str] = dict()
+        dictionary: dict[str, str] = {
+            "PowerLineFrequency": "n/a",
+            "SamplingFrequency": "n/a",
+            "SoftwareFilters": "n/a",
+        }
 
-        # TODO
+        if nwbfile.institution is not None:
+            dictionary["InstitutionName"] = nwbfile.institution
+
+        all_acquisition_electrical_series = [
+            series for series in nwbfile.acquisition.values() if isinstance(series, pynwb.ecephys.ElectricalSeries)
+        ]
+        if len(all_acquisition_electrical_series) == 1:
+            electrical_series = all_acquisition_electrical_series[0]
+
+            if electrical_series.rate is not None:
+                dictionary["SamplingFrequency"] = electrical_series.rate
+            if electrical_series.data is not None and electrical_series.rate is not None:
+                dictionary["RecordingDuration"] = electrical_series.data.shape[0] / electrical_series.rate
+
+            electrode_group = electrical_series.electrodes[0].group[0]
+            if (manufacturer := electrode_group.device.manufacturer) is not None and manufacturer != "":
+                dictionary["Manufacturer"] = manufacturer
+            if (model_number := electrode_group.device.model_number) is not None and model_number != "":
+                dictionary["ManufacturersModelVersion"] = model_number
+
+            if (brain_region := electrode_group.location) is not None or brain_region not in ["", "unknown", "n/a"]:
+                dictionary["BodyPart"] = "BRAIN"
+                dictionary["BodyPartDetails"] = brain_region
 
         general_metadata = cls(**dictionary)
         return general_metadata

--- a/src/nwb2bids/bids_models/_general_metadata.py
+++ b/src/nwb2bids/bids_models/_general_metadata.py
@@ -147,39 +147,39 @@ class GeneralMetadata(pydantic.BaseModel):
         ),
         default=None,
     )
-    BodyPart: float | None = pydantic.Field(
+    BodyPart: str | None = pydantic.Field(
         description="Body part of the organ / body region scanned.",
         default=None,
     )
-    BodyPartDetails: float | None = pydantic.Field(
+    BodyPartDetails: str | None = pydantic.Field(
         description='Additional details about body part or location (for example: "corpus callosum").',
         default=None,
     )
-    BodyPartDetailsOntology: float | None = pydantic.Field(
+    BodyPartDetailsOntology: str | None = pydantic.Field(
         description=(
             'URI of ontology used for BodyPartDetails (for example: "https://www.ebi.ac.uk/ols/ontologies/uberon").'
         ),
         default=None,
     )
-    SampleEnvironment: float | None = pydantic.Field(
+    SampleEnvironment: str | None = pydantic.Field(
         description=(
             'Environment in which the sample was imaged. MUST be one of: "in vivo", "ex vivo" or "in vitro". '
             'Must be one of: "in vivo", "ex vivo", "in vitro".'
         ),
         default=None,
     )
-    SampleEmbedding: float | None = pydantic.Field(
+    SampleEmbedding: str | None = pydantic.Field(
         description='Description of the tissue sample embedding (for example: "Epoxy resin").',
         default=None,
     )
-    SliceThickness: float | None = pydantic.Field(
+    SliceThickness: int | float | None = pydantic.Field(
         description=(
             'Slice thickness of the tissue sample in the unit micrometers ("um") (for example: 5). '
             "Must be a number greater than 0."
         ),
         default=None,
     )
-    SampleExtractionProtocol: float | None = pydantic.Field(
+    SampleExtractionProtocol: str | None = pydantic.Field(
         description="Description of the sample extraction protocol or URI (for example from protocols.io).",
         default=None,
     )

--- a/src/nwb2bids/bids_models/_general_metadata.py
+++ b/src/nwb2bids/bids_models/_general_metadata.py
@@ -281,4 +281,4 @@ class GeneralMetadata(pydantic.BaseModel):
             The path to the file where the metadata will be saved.
         """
         with pathlib.Path(file_path).open(mode="w") as file_stream:
-            json.dump(obj=self.model_dump(), fp=file_stream, indent=4)
+            json.dump(obj=self.model_dump(exclude_none=True), fp=file_stream, indent=4)

--- a/src/nwb2bids/bids_models/_general_metadata.py
+++ b/src/nwb2bids/bids_models/_general_metadata.py
@@ -263,7 +263,7 @@ class GeneralMetadata(pydantic.BaseModel):
             if (model_number := electrode_group.device.model_number) is not None and model_number != "":
                 dictionary["ManufacturersModelVersion"] = model_number
 
-            if (brain_region := electrode_group.location) is not None or brain_region not in ["", "unknown", "n/a"]:
+            if (brain_region := electrode_group.location) is not None and brain_region not in ["", "unknown", "n/a"]:
                 dictionary["BodyPart"] = "BRAIN"
                 dictionary["BodyPartDetails"] = brain_region
 

--- a/src/nwb2bids/bids_models/_general_metadata.py
+++ b/src/nwb2bids/bids_models/_general_metadata.py
@@ -239,7 +239,7 @@ class GeneralMetadata(pydantic.BaseModel):
 
         dictionary: dict[str, str | int | float | None] = {
             "PowerLineFrequency": "n/a",
-            "SamplingFrequency": "n/a",
+            "SamplingFrequency": -1.0,
             "SoftwareFilters": "n/a",
         }
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -131,6 +131,7 @@ def test_ecephys_cli(
         / "ecephys": {
             "directories": set(),
             "files": {
+                "sub-001_ses-A_ecephys.json",
                 "sub-001_ses-A_ecephys.nwb",
                 "sub-001_ses-A_channels.tsv",
                 "sub-001_ses-A_channels.json",

--- a/tests/integration/test_convert_nwb_dataset.py
+++ b/tests/integration/test_convert_nwb_dataset.py
@@ -122,6 +122,7 @@ def test_ecephys_tutorial_convert_nwb_dataset(
         / "ecephys": {
             "directories": set(),
             "files": {
+                "sub-001_ses-A_ecephys.json",
                 "sub-001_ses-A_ecephys.nwb",
                 "sub-001_ses-A_channels.tsv",
                 "sub-001_ses-A_channels.json",
@@ -340,6 +341,7 @@ def test_ecephys_minimal_convert_nwb_dataset(
         / "ecephys": {
             "directories": set(),
             "files": {
+                "sub-001_ses-A_ecephys.json",
                 "sub-001_ses-A_ecephys.nwb",
                 "sub-001_ses-A_channels.tsv",
                 "sub-001_ses-A_channels.json",

--- a/tests/integration/test_convert_nwb_dataset.py
+++ b/tests/integration/test_convert_nwb_dataset.py
@@ -384,15 +384,15 @@ def test_ecephys_minimal_convert_nwb_dataset(
     channels_tsv_file_path = temporary_bids_directory / "sub-001" / "ses-A" / "ecephys" / "sub-001_ses-A_channels.tsv"
     channels_tsv_lines = channels_tsv_file_path.read_text().splitlines()
     expected_channels_tsv_lines = [
-        "name\telectrode_name\ttype\tunits",
-        "ch000\te000\tn/a\tV",
-        "ch001\te001\tn/a\tV",
-        "ch002\te002\tn/a\tV",
-        "ch003\te003\tn/a\tV",
-        "ch004\te004\tn/a\tV",
-        "ch005\te005\tn/a\tV",
-        "ch006\te006\tn/a\tV",
-        "ch007\te007\tn/a\tV",
+        "name\telectrode_name\ttype\tunits\tsampling_frequency",
+        "ch000\te000\tn/a\tV\t-1.0",
+        "ch001\te001\tn/a\tV\t-1.0",
+        "ch002\te002\tn/a\tV\t-1.0",
+        "ch003\te003\tn/a\tV\t-1.0",
+        "ch004\te004\tn/a\tV\t-1.0",
+        "ch005\te005\tn/a\tV\t-1.0",
+        "ch006\te006\tn/a\tV\t-1.0",
+        "ch007\te007\tn/a\tV\t-1.0",
     ]
     assert channels_tsv_lines == expected_channels_tsv_lines
 

--- a/tests/integration/test_icephys_tutorial.py
+++ b/tests/integration/test_icephys_tutorial.py
@@ -37,6 +37,7 @@ def test_icephys_tutorial_file(tmpdir: py.path.local, temporary_bids_directory: 
         / "icephys": {
             "directories": set(),
             "files": {
+                "sub-001_ses-A_icephys.json",
                 "sub-001_ses-A_icephys.nwb",
                 "sub-001_ses-A_probes.json",
                 "sub-001_ses-A_probes.tsv",

--- a/tests/integration/test_remote_convert_nwb_dataset.py
+++ b/tests/integration/test_remote_convert_nwb_dataset.py
@@ -53,6 +53,7 @@ def test_remote_convert_nwb_dataset(temporary_bids_directory: pathlib.Path):
         / "ecephys": {
             "directories": set(),
             "files": {
+                "sub-YutaMouse20_ses-YutaMouse20-140321_ecephys.json",
                 "sub-YutaMouse20_ses-YutaMouse20-140321_channels.json",
                 "sub-YutaMouse20_ses-YutaMouse20-140321_channels.tsv",
                 "sub-YutaMouse20_ses-YutaMouse20-140321_ecephys.nwb",
@@ -70,6 +71,7 @@ def test_remote_convert_nwb_dataset(temporary_bids_directory: pathlib.Path):
         / "ecephys": {
             "directories": set(),
             "files": {
+                "sub-YutaMouse20_ses-YutaMouse20-140327_ecephys.json",
                 "sub-YutaMouse20_ses-YutaMouse20-140327_channels.json",
                 "sub-YutaMouse20_ses-YutaMouse20-140327_channels.tsv",
                 "sub-YutaMouse20_ses-YutaMouse20-140327_ecephys.nwb",
@@ -130,6 +132,7 @@ def test_remote_convert_nwb_dataset_on_gotten_datalad_file(
         / "ecephys": {
             "directories": set(),
             "files": {
+                "sub-fCamk1_ses-fCamk1_200827_sess9_no_raw_data_ecephys.json",
                 "sub-fCamk1_ses-fCamk1_200827_sess9_no_raw_data_channels.json",
                 "sub-fCamk1_ses-fCamk1_200827_sess9_no_raw_data_channels.tsv",
                 "sub-fCamk1_ses-fCamk1_200827_sess9_no_raw_data_ecephys.nwb",
@@ -190,6 +193,7 @@ def test_remote_convert_nwb_dataset_on_partial_datalad_dataset(
         / "ecephys": {
             "directories": set(),
             "files": {
+                "sub-fCamk1_ses-fCamk1_200827_sess9_no_raw_data_ecephys.json",
                 "sub-fCamk1_ses-fCamk1_200827_sess9_no_raw_data_channels.json",
                 "sub-fCamk1_ses-fCamk1_200827_sess9_no_raw_data_channels.tsv",
                 "sub-fCamk1_ses-fCamk1_200827_sess9_no_raw_data_ecephys.nwb",

--- a/tests/unit/test_dataset_converter.py
+++ b/tests/unit/test_dataset_converter.py
@@ -72,6 +72,7 @@ def test_dataset_converter_metadata_extraction(
                 participant=nwb2bids.bids_models.Participant(
                     participant_id="123", species="Mus musculus", sex="M", strain=None
                 ),
+                general_metadata=nwb2bids.bids_models.GeneralMetadata(),
                 run_config=run_config,
             ),
             modality="ecephys",

--- a/tests/unit/test_session_converter.py
+++ b/tests/unit/test_session_converter.py
@@ -124,6 +124,7 @@ def test_session_converter_write_ecephys_metadata(
         / "ecephys": {
             "directories": set(),
             "files": {
+                "sub-001_ses-A_ecephys.json",
                 "sub-001_ses-A_probes.tsv",
                 "sub-001_ses-A_probes.json",
                 "sub-001_ses-A_channels.tsv",

--- a/tests/unit/test_session_converter.py
+++ b/tests/unit/test_session_converter.py
@@ -86,6 +86,7 @@ def test_session_converter_metadata_extraction(
     expected_session_metadata = nwb2bids.bids_models.BidsSessionMetadata(
         session_id="456",
         participant=nwb2bids.bids_models.Participant(participant_id="123", species="Mus musculus", sex="M"),
+        general_metadata=nwb2bids.bids_models.GeneralMetadata(),
         run_config=run_config,
     )
     assert session_converter.session_metadata == expected_session_metadata


### PR DESCRIPTION
The now-required `ecephys`/`icephys` files

Refer to metadata definitions: https://bids-specification--2307.org.readthedocs.build/en/2307/modality-specific-files/microelectrode-electrophysiology.html#sidecar-json-_icephysjson-and-_ecephysjson