### PR TITLE
Fixed failing remote tests

### DIFF
--- a/src/nwb2bids/_converters/_dataset_converter.py
+++ b/src/nwb2bids/_converters/_dataset_converter.py
@@ -47,6 +47,7 @@ class DatasetConverter(BaseConverter):
         cls,
         dandiset_id: str = pydantic.Field(pattern=r"^\d{6}$"),
         api_url: str | None = None,
+        version_id: str = "draft",
         token: str | None = None,
         limit: int | None = None,
         run_config: RunConfig = pydantic.Field(default_factory=lambda: RunConfig()),
@@ -63,6 +64,8 @@ class DatasetConverter(BaseConverter):
             DANDI instance specified by the :envvar:`DANDI_INSTANCE` environment variable
             is used. If the :envvar:`DANDI_INSTANCE` environment variable is not specified,
             The API URL of the `"dandi"` DANDI instance is used.
+        version_id : str, default: "draft"
+            The version ID of the Dandiset to be converted.
         token : str, optional
             The authentication token for accessing the DANDI instance.
             If not provided, will attempt to read from the environment variable `DANDI_API_KEY` if it exists.
@@ -77,7 +80,6 @@ class DatasetConverter(BaseConverter):
             import dandi.dandiapi
 
             client = dandi.dandiapi.DandiAPIClient(api_url=api_url, token=token)
-            version_id = "draft"  # Only allow running on draft version
             dandiset = client.get_dandiset(dandiset_id=dandiset_id, version_id=version_id)
 
             dataset_description, _internal_notifications = get_bids_dataset_description(dandiset=dandiset)

--- a/tests/unit/test_remote_dataset_converter.py
+++ b/tests/unit/test_remote_dataset_converter.py
@@ -89,7 +89,7 @@ def test_remote_dataset_converter_metadata_extraction(temporary_bids_directory: 
 def test_remote_dataset_converter_initialization_on_invalid_metadata(temporary_bids_directory: pathlib.Path):
     run_config = nwb2bids.RunConfig(bids_directory=temporary_bids_directory)
     dataset_converter = nwb2bids.DatasetConverter.from_remote_dandiset(
-        dandiset_id="000005", limit=2, run_config=run_config
+        dandiset_id="000005", version_id="0.220126.1853", limit=2, run_config=run_config
     )
     assert isinstance(dataset_converter, nwb2bids.DatasetConverter)
 


### PR DESCRIPTION
Since it timed out around the same point in time, I figured this failure was due to something upstream...

And perhaps it was (draft version of this Dandiset was invalid but now seems valid?) but maybe that will not change any more (possible bug fix?)

Trying this in CI, seemed to work locally