### PR TITLE
Fix up testing against DataLad on Windows

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -69,10 +69,22 @@ jobs:
 
       - if: runner.os == 'Windows'
         name: Enable long path support on Windows
-        run: git config --global core.longpaths true
+        run: |
+          git config --global core.longpaths true
+          mkdir C:\t
+
+      - name: Show git-annex version info
+        run: git-annex version
+
+      - if: ${{ inputs.pytest_markexpr == 'remote' }}
+        name: Show datalad environment info
+        run: datalad wtf
 
       - name: Run tests
-        run: python -m pytest -m "${{ inputs.pytest_markexpr }}" -vv --cov=nwb2bids --cov-report xml:./codecov.xml
+        run: >-
+          python -m pytest -m "${{ inputs.pytest_markexpr }}" -vv
+          --cov=nwb2bids --cov-report xml:./codecov.xml
+          ${{ runner.os == 'Windows' && '--basetemp C:\t' || '' }}
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/tests/integration/test_remote_convert_nwb_dataset.py
+++ b/tests/integration/test_remote_convert_nwb_dataset.py
@@ -90,7 +90,6 @@ def test_remote_convert_nwb_dataset(temporary_bids_directory: pathlib.Path):
 
 
 @pytest.mark.remote
-@pytest_mark_xfail_windows_github_ci
 def test_remote_convert_nwb_dataset_on_gotten_datalad_file(
     testing_files_directory: pathlib.Path, temporary_bids_directory: pathlib.Path
 ):
@@ -151,7 +150,6 @@ def test_remote_convert_nwb_dataset_on_gotten_datalad_file(
 
 
 @pytest.mark.remote
-@pytest_mark_xfail_windows_github_ci
 def test_remote_convert_nwb_dataset_on_partial_datalad_dataset(
     testing_files_directory: pathlib.Path, temporary_bids_directory: pathlib.Path
 ):

--- a/tests/integration/test_remote_convert_nwb_dataset.py
+++ b/tests/integration/test_remote_convert_nwb_dataset.py
@@ -1,18 +1,8 @@
-import os
 import pathlib
-import sys
 
 import pytest
 
 import nwb2bids
-
-# These tests fail on Windows GitHub CI due to git-annex adjusted branch issues
-# See https://github.com/con/nwb2bids/pull/213 for failure output
-pytest_mark_xfail_windows_github_ci = pytest.mark.xfail(
-    sys.platform == "win32" and os.environ.get("GITHUB_ACTIONS", "").lower() == "true",
-    reason="git-annex adjusted branch fails on Windows GitHub CI runners",
-    strict=False,
-)
 
 
 @pytest.mark.remote


### PR DESCRIPTION
TODOs
- [x] see if still fails and how
- [x] if "too long" -- try higher dir, like c:/tmp (I thought I did)
- if "too long" -- try using md5e backend instead of default sha256e -- impossible
- [x] Closes #213 