### PR TITLE
Fixed author extraction for dandisets without dcite:Author role

### DIFF
--- a/src/nwb2bids/_converters/_dandi_utils.py
+++ b/src/nwb2bids/_converters/_dandi_utils.py
@@ -58,11 +58,7 @@ def _get_dataset_description_from_valid_dandiset_metadata(
             if role.value == "dcite:Author"
         ]
         if not authors:
-            authors = [
-                contributor.name
-                for contributor in metadata.contributor
-                if contributor.schemaKey == "Person"
-            ]
+            authors = [contributor.name for contributor in metadata.contributor if contributor.schemaKey == "Person"]
         dataset_description_kwargs["Authors"] = authors
     if metadata.license is not None:
         dataset_description_kwargs["License"] = metadata.license[0].value.split(":")[1]

--- a/src/nwb2bids/_converters/_dandi_utils.py
+++ b/src/nwb2bids/_converters/_dandi_utils.py
@@ -51,12 +51,19 @@ def _get_dataset_description_from_valid_dandiset_metadata(
     if metadata.description is not None:
         dataset_description_kwargs["Description"] = metadata.description
     if metadata.contributor is not None:
-        dataset_description_kwargs["Authors"] = [
+        authors = [
             contributor.name
             for contributor in metadata.contributor
             for role in contributor.roleName
             if role.value == "dcite:Author"
         ]
+        if not authors:
+            authors = [
+                contributor.name
+                for contributor in metadata.contributor
+                if contributor.schemaKey == "Person"
+            ]
+        dataset_description_kwargs["Authors"] = authors
     if metadata.license is not None:
         dataset_description_kwargs["License"] = metadata.license[0].value.split(":")[1]
 
@@ -95,7 +102,13 @@ def _get_dataset_description_from_invalid_dandiset_metadata(
         if contributor_name is not None and is_author:
             bids_authors.append(contributor_name)
 
-    if any(bids_authors):
+    if not bids_authors:
+        for contributor in dandiset_contributors:
+            contributor_name = contributor.get("name", None)
+            if contributor_name is not None and contributor.get("schemaKey", "") == "Person":
+                bids_authors.append(contributor_name)
+
+    if bids_authors:
         dataset_description_kwargs["Authors"] = bids_authors
 
     license = raw_metadata.get("license", [])

--- a/tests/unit/test_dandi_utils.py
+++ b/tests/unit/test_dandi_utils.py
@@ -1,0 +1,46 @@
+"""Unit tests for the `_dandi_utils` module."""
+
+import pytest
+
+from nwb2bids._converters._dandi_utils import _get_dataset_description_from_invalid_dandiset_metadata
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    "contributors, expected_authors",
+    [
+        pytest.param(
+            [
+                {"name": "Author, One", "schemaKey": "Person", "roleName": ["dcite:Author"]},
+                {"name": "Contact, Two", "schemaKey": "Person", "roleName": ["dcite:ContactPerson"]},
+                {"name": "Some Org", "schemaKey": "Organization", "roleName": []},
+            ],
+            ["Author, One"],
+            id="dcite_author_takes_precedence",
+        ),
+        pytest.param(
+            [
+                {"name": "Gouwens, Nathan", "schemaKey": "Person", "roleName": ["dcite:ContactPerson"]},
+                {"name": "Allen Institute for Brain Science", "schemaKey": "Organization", "roleName": []},
+            ],
+            ["Gouwens, Nathan"],
+            id="fallback_to_persons_excludes_orgs",
+        ),
+        pytest.param(
+            [
+                {"name": "Some Organization", "schemaKey": "Organization", "roleName": []},
+            ],
+            None,
+            id="org_only_yields_none",
+        ),
+    ],
+)
+def test_author_extraction_from_invalid_metadata(contributors, expected_authors):
+    """Author extraction: dcite:Author preferred, then Person fallback (skip Organizations)."""
+    raw_metadata = {
+        "name": "Test Dandiset",
+        "assetsSummary": {"dataStandard": []},
+        "contributor": contributors,
+    }
+    description, _ = _get_dataset_description_from_invalid_dandiset_metadata(raw_metadata=raw_metadata)
+    assert description.Authors == expected_authors


### PR DESCRIPTION
When no contributor has roleName "dcite:Author", fall back to all contributors with schemaKey "Person" (skipping Organizations). Fixes #373 where dandiset 000020 produced an empty Authors list.

Co-Authored-By: Claude Code 2.1.107 / Claude Opus 4.6 <noreply@anthropic.com>

I submitted a PR

- https://github.com/bids-standard/bids-specification/pull/2397 to allow for Organization in Authors

but also BIDS already supports use of CITATION.cff, and (according to claude):

  CFF supports organizations natively

  In CITATION.cff, authors can be either person or entity:

  authors:
    - given-names: Nathan family-names: Gouwens
    - name: "Allen Institute for Brain Science"    # entity — just needs "name"
      website: https://alleninstitute.org

  The distinction is structural: name field → entity, given-names/family-names → person. They can be freely mixed in the authors list.

so this work potentially should potentially just wait for decision on #2397 to allow Organizations and thus change the fix to include organizations in particular if told to be included in citation, and/or produce CITATION.cff; but ATM we produce CITATION.cff only in dandi-archive frontend, so there is no python level support ATM.