### PR TITLE
Update email sender format in GitHub Actions workflows

### DIFF
--- a/.github/workflows/daily_doc_link_check.yml
+++ b/.github/workflows/daily_doc_link_check.yml
@@ -40,5 +40,5 @@ jobs:
           password: ${{ secrets.MAIL_PASSWORD }}
           subject: "CI Failure: nwb2bids Daily Doc Link Check"
           to: cody.c.baker.phd@gmail.com  # Add more with comma separation (no spaces)
-          from: nwb2bids
+          from: nwb2bids <nwb2bids@users.noreply.github.com>
           body: "The daily doc link check workflow failed, please check status at https://github.com/con/nwb2bids/actions/workflows/daily_doc_link_check.yml"

--- a/.github/workflows/daily_remote_tests.yml
+++ b/.github/workflows/daily_remote_tests.yml
@@ -32,5 +32,5 @@ jobs:
           password: ${{ secrets.MAIL_PASSWORD }}
           subject: "CI Failure: nwb2bids Daily Tests (Remote)"
           to: cody.c.baker.phd@gmail.com  # Add more with comma separation (no spaces)
-          from: nwb2bids
+          from: nwb2bids <nwb2bids@users.noreply.github.com>
           body: "The daily tests (remote) workflow failed, please check status at https://github.com/con/nwb2bids/actions/workflows/daily_remote_tests.yml"

--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -32,5 +32,5 @@ jobs:
           password: ${{ secrets.MAIL_PASSWORD }}
           subject: "CI Failure: nwb2bids Daily Tests"
           to: cody.c.baker.phd@gmail.com  # Add more with comma separation (no spaces)
-          from: nwb2bids
+          from: nwb2bids <nwb2bids@users.noreply.github.com>
           body: "The daily test workflow failed, please check status at https://github.com/con/nwb2bids/actions/workflows/daily_tests.yml"

--- a/.github/workflows/notify_on_major_version_label.yml
+++ b/.github/workflows/notify_on_major_version_label.yml
@@ -18,5 +18,5 @@ jobs:
           password: ${{ secrets.MAIL_PASSWORD }}
           subject: "Major version label applied to nwb2bids PR #${{ github.event.pull_request.number }}"
           to: cody.c.baker.phd@gmail.com
-          from: nwb2bids
+          from: nwb2bids <nwb2bids@users.noreply.github.com>
           body: "The 'major' label has been applied to PR #${{ github.event.pull_request.number }} ('${{ github.event.pull_request.title }}') in the nwb2bids project. Please review at ${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
## Summary
Updated the `from` field in email notifications across all GitHub Actions workflows to use a properly formatted email address with display name, following standard email format conventions.

## Changes
- Updated `from` field in 4 workflow files:
  - `.github/workflows/daily_doc_link_check.yml`
  - `.github/workflows/daily_remote_tests.yml`
  - `.github/workflows/daily_tests.yml`
  - `.github/workflows/notify_on_major_version_label.yml`
- Changed from: `nwb2bids` → `nwb2bids <nwb2bids@users.noreply.github.com>`

## Details
The email sender format now follows the standard RFC 5322 format with both a display name and email address. This uses GitHub's noreply email address to ensure proper email delivery and authentication, while maintaining the project name as the display name for clarity in recipients' inboxes.

https://claude.ai/code/session_01Cymni5fTE6RhQZwb8Cc7Hs