### PR TITLE
Update GitHub Actions workflows: upgrade checkout to v6 and add permissions

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Download Latest Auto Binary

--- a/.github/workflows/build_and_upload_docker_image_dev.yml
+++ b/.github/workflows/build_and_upload_docker_image_dev.yml
@@ -7,13 +7,17 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-test-push:
     name: Build and test dev image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build_and_upload_docker_image_latest.yml
+++ b/.github/workflows/build_and_upload_docker_image_latest.yml
@@ -6,13 +6,17 @@ on:
     workflows: [Upload Package to PyPI]
     types: [completed]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   release-image:
     name: Build and upload Docker image of dev branch to GHCR
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Parse the version from the GitHub latest release tag
         id: parsed_version
         run: |

--- a/.github/workflows/custom_dispatch_tests.yml
+++ b/.github/workflows/custom_dispatch_tests.yml
@@ -26,6 +26,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/daily_doc_link_check.yml
+++ b/.github/workflows/daily_doc_link_check.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'

--- a/.github/workflows/daily_remote_tests.yml
+++ b/.github/workflows/daily_remote_tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 12 * * *'  # 7 am EST every day
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -23,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ DailyRemoteTests ]
     if: ${{ always() && needs.DailyRemoteTests.result == 'failure' }}
+    permissions: {}
     steps:
       - uses: dawidd6/action-send-mail@v17
         with:

--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 12 * * *'  # 7 am EST every day
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -23,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ DailyTests ]
     if: ${{ always() && needs.DailyTests.result == 'failure' }}
+    permissions: {}
     steps:
       - uses: dawidd6/action-send-mail@v17
         with:

--- a/.github/workflows/deploy_tests_on_pull_request.yml
+++ b/.github/workflows/deploy_tests_on_pull_request.yml
@@ -32,7 +32,7 @@ jobs:
   DocTests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
@@ -46,7 +46,7 @@ jobs:
   DocLinkCheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'

--- a/.github/workflows/publish_to_pypi_on_github_release.yml
+++ b/.github/workflows/publish_to_pypi_on_github_release.yml
@@ -4,11 +4,14 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/require_labels_on_pull_request.yml
+++ b/.github/workflows/require_labels_on_pull_request.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   label-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -6,6 +6,9 @@ on:
       - 'containers/**'
       - '.dockerignore'
 
+permissions:
+  contents: read
+
 jobs:
   test-build:
     name: Test Docker build
@@ -19,7 +22,7 @@ jobs:
             target: all
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Set up environment
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions workflows to improve security and maintain compatibility by upgrading the `actions/checkout` action to v6 across all workflows and adding explicit permission declarations.

## Key Changes
- **Upgraded `actions/checkout`**: Updated from v3, v4, and v5 to v6 across all workflow files
- **Added explicit permissions**: Added `permissions` blocks to all workflows following the principle of least privilege:
  - Workflows requiring package access: `contents: read` and `packages: write`
  - Workflows requiring pull request access: `contents: read` and `pull-requests: read`
  - Workflows with minimal needs: `contents: read` only
  - Email notification jobs: `permissions: {}` (no permissions needed)

## Affected Workflows
- `build_and_upload_docker_image_dev.yml`
- `build_and_upload_docker_image_latest.yml`
- `publish_to_pypi_on_github_release.yml`
- `test_docker_build.yml`
- `daily_remote_tests.yml`
- `daily_tests.yml`
- `deploy_tests_on_pull_request.yml`
- `require_labels_on_pull_request.yml`
- `custom_dispatch_tests.yml`
- `auto_release.yml`
- `daily_doc_link_check.yml`
- `testing.yml`

## Notable Implementation Details
- Email notification jobs in daily test workflows explicitly set `permissions: {}` since they don't require GitHub API access
- Permission declarations are placed at the workflow level for global application, with job-level overrides where needed
- The upgrade to checkout v6 ensures compatibility with the latest GitHub Actions runtime and security improvements

https://claude.ai/code/session_01H6WFEMn5kLR6RDftNVhvSr