### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete regular expression for hostnames

### DIFF
--- a/src/nwb2bids/bids_models/_model_globals.py
+++ b/src/nwb2bids/bids_models/_model_globals.py
@@ -1,5 +1,5 @@
 _VALID_ID_REGEX = r"^[A-Za-z0-9+]+"
-_VALID_SPECIES_REGEX = r"([A-Z][a-z]* [a-z]+)|(http://purl.obolibrary.org/obo/NCBITaxon_\d+)"
+_VALID_SPECIES_REGEX = r"([A-Z][a-z]* [a-z]+)|(http://purl\.obolibrary\.org/obo/NCBITaxon_\d+)"
 _VALID_BIDS_SEXES = {
     value: True
     for value in [


### PR DESCRIPTION
Potential fix for [https://github.com/con/nwb2bids/security/code-scanning/1](https://github.com/con/nwb2bids/security/code-scanning/1)

To fix this, escape literal dots in the URL branch of `_VALID_SPECIES_REGEX` so the regex matches the exact hostname/path structure intended, not arbitrary characters.  
The best minimal fix is to change:

- `http://purl.obolibrary.org/obo/NCBITaxon_\d+`

to:

- `http://purl\.obolibrary\.org/obo/NCBITaxon_\d+`

in `src/nwb2bids/bids_models/_model_globals.py` line 2.

No new imports, helper methods, or dependency changes are required. This preserves existing functionality while tightening matching semantics to the intended host format.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
