### PR TITLE
Fix Google Analytics tracking for returning visitors with consent

### DIFF
--- a/docs/_static/cookie-consent.js
+++ b/docs/_static/cookie-consent.js
@@ -25,6 +25,13 @@ document.addEventListener('DOMContentLoaded', function () {
                                 gtag('consent', 'update', {
                                     analytics_storage: 'granted'
                                 });
+                                // gtag already processed its config while GA
+                                // was disabled, dropping the initial
+                                // page_view — re-send it exactly once.
+                                if (window['nwb2bids-ga-pageview-suppressed']) {
+                                    window['nwb2bids-ga-pageview-suppressed'] = false;
+                                    gtag('event', 'page_view');
+                                }
                             }
                         },
                         onReject: () => {

--- a/docs/_static/ga-consent-init.js
+++ b/docs/_static/ga-consent-init.js
@@ -1,11 +1,31 @@
 // Google Consent Mode v2 — deny until user opts-in
 window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
+
+// vanilla-cookieconsent persists choices in the 'cc_cookie' cookie; read it
+// here (before gtag loads) so returning visitors who already accepted
+// analytics are tracked from the very first hit of the page load.
+function nwb2bidsHasAnalyticsConsent() {
+    try {
+        var match = document.cookie.match(/(?:^|;\s*)cc_cookie=([^;]*)/);
+        if (!match) return false;
+        var consent = JSON.parse(decodeURIComponent(match[1]));
+        return Array.isArray(consent.categories) && consent.categories.indexOf('analytics') !== -1;
+    } catch (error) {
+        return false;
+    }
+}
+
+var nwb2bidsAnalyticsGranted = nwb2bidsHasAnalyticsConsent();
+
 gtag('consent', 'default', {
-    'analytics_storage': 'denied',
+    'analytics_storage': nwb2bidsAnalyticsGranted ? 'granted' : 'denied',
     'ad_storage': 'denied',
     'wait_for_update': 500
 });
 
-// Disable GA until consent given
-window['ga-disable-G-KS7XCX3H2L'] = true;
+// Disable GA until consent given. gtag fires its page_view while this flag is
+// set, so cookie-consent.js re-sends it after a first-time accept (tracked
+// via the flag below).
+window['ga-disable-G-KS7XCX3H2L'] = !nwb2bidsAnalyticsGranted;
+window['nwb2bids-ga-pageview-suppressed'] = !nwb2bidsAnalyticsGranted;


### PR DESCRIPTION
## Summary
This change fixes Google Analytics tracking for returning visitors who have already given consent. Previously, the initial page view was not being tracked for these users because GA was disabled at page load time, even though their consent preference was already stored.

## Key Changes
- **ga-consent-init.js**: 
  - Added `nwb2bidsHasAnalyticsConsent()` function to read the `cc_cookie` cookie and check if the user has previously granted analytics consent
  - Modified the initial `gtag('consent', 'default')` call to set `analytics_storage` to `'granted'` for returning visitors with consent, instead of always denying
  - Changed the GA disable flag to only be set when consent has NOT been granted, allowing GA to function immediately for returning visitors
  - Added a new flag `nwb2bids-ga-pageview-suppressed` to track whether the initial page view was suppressed

- **cookie-consent.js**:
  - Added logic to re-send the initial `page_view` event when a first-time user accepts analytics consent
  - This ensures the page view is tracked exactly once, even though gtag's config was processed while GA was disabled

## Implementation Details
The solution handles two scenarios:
1. **Returning visitors with consent**: GA is enabled immediately at page load, so the initial page view is tracked normally
2. **First-time visitors**: GA remains disabled until consent is given, then the suppressed page view event is manually re-sent after consent is granted

This approach ensures accurate tracking from the first page load for users who have already consented, while maintaining privacy for new visitors until they opt-in.

https://claude.ai/code/session_011759EbwXSPK4TJwd5nnMaS